### PR TITLE
Consistently use the same filter for required user capabilities

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -33,7 +33,7 @@ class RedirectionAjax extends Redirection_Plugin {
 	}
 
 	function init() {
-		if ( current_user_can( 'administrator' ) ) {
+		if ( current_user_can( apply_filters( 'redirection_role', 'administrator' ) ) ) {
 			$this->post = stripslashes_deep( $_POST );
 
 			$this->register_ajax( 'red_log_show' );


### PR DESCRIPTION
In redirection.php, line 130:
apply_filters( 'redirection_role', 'administrator' )
is used so that the required capabilities for using 'Redirection' can be modified without modifing the plugin itself.

I think that the same filter should be used in ajax.php
