### PR TITLE
Fix for PHP Fatal error

### DIFF
--- a/models/pager.php
+++ b/models/pager.php
@@ -128,7 +128,7 @@ class Redirection_Table extends WP_List_Table {
 		}
 	}
 
-	protected function extra_tablenav( $which ) {
+	function extra_tablenav( $which ) {
 		if ( $which == 'bottom' )
 			return;
 


### PR DESCRIPTION
I am getting the following error 

``````
 PHP Fatal error:  Access level to Redirection_Table::extra_tablenav() must be public (as in class WP_List_Table) in /var/www/inspirewp/web/wp-content/plugins/redirection/models/pager.php on line 204```

This is because this method was set to protected for some reason.
``````
