### PR TITLE
Added support for CSV files added from Mac OS

### DIFF
--- a/fileio/csv.php
+++ b/fileio/csv.php
@@ -1,5 +1,7 @@
 <?php
 
+@ini_set("auto_detect_line_endings", true);
+
 class Red_Csv_File extends Red_FileIO {
 	function export( array $items ) {
 		$filename = 'redirection-'.date_i18n( get_option( 'date_format' ) ).'.csv';


### PR DESCRIPTION
When CSV files are generated on a Mac OS, they have different line-endings which result in fgetcsv to fail after detecting the first line. This also leads to new lines being imported at every 1000th character position irrespective of the line breaks because of the length limit in line no 39.

Signed-off-by: islahul islahulzunjani@gmail.com
