### PR TITLE
Fix table name in 404s export SQL

### DIFF
--- a/models/log.php
+++ b/models/log.php
@@ -241,7 +241,7 @@ class RE_404 {
 		fputcsv( $stdout, array( 'date', 'source', 'ip', 'referrer' ) );
 
 		$extra = '';
-		$sql = "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_logs";
+		$sql = "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_404";
 		if ( isset( $_REQUEST['s'] ) )
 			$extra = $wpdb->prepare( " WHERE url LIKE %s", '%'.like_escape( $_REQUEST['s'] ).'%' );
 


### PR DESCRIPTION
This corrects the SQL statement to retrieve the number of 404s for export to CSV. The correct table name is 'redirection_404', not 'redirection_logs'.

Per issue: https://github.com/johngodley/redirection/issues/39