### PR TITLE
Removed all redirects on a new permalink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "MarkArts/redirection",
+    "description": "This is a fork of johngodley/redirection with a bugfix",
+    "license": "GNU GENERAL PUBLIC LICENSE",
+    "type": "wordpress-plugin",
+    "authors": [
+        {
+          "name":"johngodley"
+        },
+        {
+            "name": "Mark Arts",
+            "email": "markarts@hoppinger.com"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {}
+}

--- a/models/monitor.php
+++ b/models/monitor.php
@@ -31,10 +31,19 @@ class Red_Monitor {
 			return;
 
 		if ( isset( $_POST['redirection_slug'] ) ) {
+
 			$after  = parse_url( get_permalink( $post_id ) );
 			$after  = $after['path'];
 			$before = esc_url( $_POST['redirection_slug'] );
 			$site   = parse_url( get_site_url() );
+
+			// Delete all redirects on the new permalink to make sure that it doesn't redirect to another post
+			if(Red_Item::exists($after))
+			{
+				foreach (Red_Item::get_for_url($after, "wp") as $red_item) {
+					$red_item->delete();
+				}
+			}
 
 			if ( in_array( $post->post_status, array( 'publish', 'static' ) ) && $before != $after && $before != '/' && ( !isset( $site['path'] ) || ( isset( $site['path'] ) && $before != $site['path'].'/' ) ) ) {
 				Red_Item::create( array(


### PR DESCRIPTION
Currently when you make a post with the permalink /testPermalink and later chance it too /testPermalinkChanged a new post with the permalink /testPermalink will redirect to /testPermalinkChanged.

This change will make sure that after a post is updated all redirects on the new permalink will be removed.