### PR TITLE
Add a filter to $url in init()

### DIFF
--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -19,6 +19,8 @@ class WordPress_Module extends Red_Module {
 	public function init() {
 		$url = $_SERVER['REQUEST_URI'];
 
+		$url = apply_filters( 'redirection_url', $url );
+
 		// Make sure we don't try and redirect something essential
 		if ( !$this->protected_url( $url ) && $this->matched === false ) {
 			do_action( 'redirection_first', $url, $this );


### PR DESCRIPTION
By allowing developers to filter the $url, we can customize our installation and avoid complicated regex rules. My sites never care about query variables but we always have to account for them in our redirections with complicated regex statements. By filtering the $url, we can chop off the query part of a URL and never have to deal with it in the redirection rule.

I initially proposed this change and gave examples here https://wordpress.org/support/topic/making-it-easy-to-redirect-without-regex
