### PR TITLE
Create tables on activation fix

### DIFF
--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -44,6 +44,11 @@ class Redirection_Admin {
 	}
 
 	public static function plugin_activated() {
+		include dirname( REDIRECTION_FILE ).'/models/database.php';
+		
+		$db = new RE_Database();
+		$db->install();
+		
 		Red_Flusher::schedule();
 	}
 


### PR DESCRIPTION
There is an issue with the plugin right now where the tables do not get created when activating the plugin.  Not sure if this is the intended method, but it's a fix none-the-less.