### PR TITLE
Problems with purging of *redirection_logs and *redirection_404

### DIFF
--- a/models/flusher.php
+++ b/models/flusher.php
@@ -4,7 +4,7 @@ class Red_Flusher {
 	const DELETE_HOOK = 'redirection_log_delete';
 	const DELETE_FREQ = 'daily';
 	const DELETE_MAX = 1000;
-	const DELETE_KEEP_ON = 15;  // 15 minutes
+	const DELETE_KEEP_ON = 5;  // 5 minutes
 
 	public function flush() {
 		$total = 0;
@@ -14,11 +14,11 @@ class Red_Flusher {
 		$total += $this->expire_404( $options['expire_404'] );
 
 		if ( $total >= self::DELETE_MAX ) {
-			$next = time() + self::DELETE_KEEP_ON;
+			$next = time() + self::DELETE_KEEP_ON * 60;
 
 			// There are still more logs to clear - keep on doing until we've clean or until the next normal event
 			if ( $next < wp_next_scheduled( self::DELETE_HOOK ) ) {
-				wp_schedule_single_event( time() + ( self::DELETE_KEEP_ON * 60 ), self::DELETE_HOOK );
+				wp_schedule_single_event( time() + $next, self::DELETE_HOOK );
 			}
 		}
 
@@ -26,7 +26,7 @@ class Red_Flusher {
 	}
 
 	private function optimize_logs() {
-		$rand = mt_rand( 1, 5000 );
+		$rand = mt_rand( 1, 100 );
 
 		if ( $rand === 11 )
 			$wpdb->query( "OPTIMIZE TABLE {$wpdb->prefix}redirection_logs" );

--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -41,9 +41,12 @@ class Redirection_Admin {
 		add_action( 'wp_ajax_red_get_nginx', array( &$this, 'ajax_get_nginx' ) );
 
 		$this->monitor = new Red_Monitor( red_get_options() );
+        $current = get_option( 'active_plugins' );
+        if ( array_search( basename( dirname( REDIRECTION_FILE ) ).'/'.basename( REDIRECTION_FILE ), $current ) !== false ) // If currently active
+            Red_Flusher::schedule(); // To ensure that a cron exists on upgrade.
 	}
 
-	public static function plugin_activated() {
+	public static function plugin_activated() { // Not fired on an upgrade.
 		Redirection_Admin::update();
 		Red_Flusher::schedule();
 	}

--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -41,8 +41,8 @@ class Redirection_Admin {
 		add_action( 'wp_ajax_red_get_nginx', array( &$this, 'ajax_get_nginx' ) );
 
 		$this->monitor = new Red_Monitor( red_get_options() );
-        $current = get_option( 'active_plugins' );
-        if ( array_search( basename( dirname( REDIRECTION_FILE ) ).'/'.basename( REDIRECTION_FILE ), $current ) !== false ) // If currently active
+        $activePluginsArray = get_option( 'active_plugins' );
+        if ( !empty( $activePluginsArray ) and is_array( $activePluginsArray ) and array_search( basename( dirname( REDIRECTION_FILE ) ) . '/' . basename( REDIRECTION_FILE ), $activePluginsArray ) !== false ) // If currently active
             Red_Flusher::schedule(); // To ensure that a cron exists on upgrade.
 	}
 


### PR DESCRIPTION
As per emails here are the code changes I made to cleanup problems with the *redirect_logs and *redirection_404 tables not being purged.
The initial cause is with longer standing installations where the plugin was already installed and active and the purging dates and settings have never needed adjusting or reserving. As a result when the purging was introduced or modified through subsequent updates the plugin was never re-activated and the Red_Flusher::schedule(); was never run.
These blogs then built up hundreds of thousands of entries in the tables. The changes are in flusher.php which I have run in the modified form on a number of blogs. Old blogs could use this alone by manually de-acrtivating and manually re-activating the plugin in order to create the daily cron entry. The second change to redirection-admin.php is an attempt to have the Red_Flusher::schedule() run on update if the plugin is already currently active. This is trickier to test as I would need to remove the cron and then practice an update in order to fire the same sequence of actions. My changes to redirection-admin.php are untested. The changes to flusher.php are tested and worked well with two sites with over 500,000 records that needed purging after a manual de-activate and re-activate.
