### PR TITLE
adding the missing `Text Domain` to the file header

### DIFF
--- a/redirection.php
+++ b/redirection.php
@@ -6,6 +6,7 @@ Description: Manage all your 301 redirects and monitor 404 errors
 Version: 2.4.3
 Author: John Godley
 Author URI: http://urbangiraffe.com
+Text Domain: redirection
 ============================================================================================================
 This software is provided "as is" and any express or implied warranties, including, but not limited to, the
 implied warranties of merchantibility and fitness for a particular purpose are disclaimed. In no event shall


### PR DESCRIPTION
When there is no `Text Domain` information in the plugin file header, WordPress will not search for localization files in the directory `wp-conten/languages/plugins`. This is the directory where the translation from https://translate.wordpress.org/ will be updated to.