### PR TITLE
Update log.php

### DIFF
--- a/models/log.php
+++ b/models/log.php
@@ -83,7 +83,8 @@ class RE_Log {
 			$where[] = $wpdb->prepare( 'redirection_id=%d', $id );
 
 		if ( isset( $_REQUEST['s'] ) )
-			$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+			$like = $wpdb->esc_like( $_REQUEST['s'] );
+			$where[] = $wpdb->prepare( 'url LIKE %s', '%'. $like .'%' );
 
 		$where_cond = '';
 		if ( count( $where ) > 0 )
@@ -109,7 +110,8 @@ class RE_Log {
 		$extra = '';
 		$sql = "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_logs";
 		if ( isset( $_REQUEST['s'] ) )
-			$extra = $wpdb->prepare( ' WHERE url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+			$like = $wpdb->esc_like( $_REQUEST['s'] );
+			$extra = $wpdb->prepare( ' WHERE url LIKE %s', '%'. $like .'%' );
 
 		$total_items = $wpdb->get_var( $sql.$extra );
 		$exported = 0;
@@ -191,7 +193,8 @@ class RE_404 {
 
 		$where = array();
 		if ( isset( $_REQUEST['s'] ) )
-			$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+			$like = $wpdb->esc_like( $_REQUEST['s'] );
+			$where[] = $wpdb->prepare( 'url LIKE %s', '%'. $like .'%' );
 
 		$where_cond = '';
 		if ( count( $where ) > 0 )
@@ -217,7 +220,8 @@ class RE_404 {
 		$extra = '';
 		$sql = "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_404";
 		if ( isset( $_REQUEST['s'] ) )
-			$extra = $wpdb->prepare( ' WHERE url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+			$like = $wpdb->esc_like( $_REQUEST['s'] );
+			$extra = $wpdb->prepare( ' WHERE url LIKE %s', '%'. $like .'%' );
 
 		$total_items = $wpdb->get_var( $sql.$extra );
 		$exported = 0;


### PR DESCRIPTION
to increase security for logs esc_like should always come before prepare "reversing the order is very bad for security" per wordpress code reference https://developer.wordpress.org/reference/classes/wpdb/esc_like/
