### PR TITLE
Hotfix item-edit.php Group Select

### DIFF
--- a/view/item-edit.php
+++ b/view/item-edit.php
@@ -18,7 +18,7 @@
 		<th width="100"><?php _e( 'Group', 'redirection' ); ?>:</th>
 		<td>
 			<select name="group_id">
-				<?php echo $this->select( Red_Group::get_for_select(), $redirect->get_group_id() );?>
+				<?php echo $this->select( Red_Group::get_for_select(), intval( $redirect->get_group_id(), 10 ) );?>
 			</select>
 		</td>
 	</tr>


### PR DESCRIPTION
Fix issue with Redirect items showing the first group as their selected group no matter what group is selected.
Cast redirect group id to integer in order to satisfy Redirection_Admin::select() === test for selected value.
