### PR TITLE
Feature: Add Rule Position Modification and Order By Rule Execution

### DIFF
--- a/models/pager.php
+++ b/models/pager.php
@@ -186,11 +186,11 @@ class Redirection_Table extends WP_List_Table {
 		// Process any stuff
 		$this->process_bulk_action();
 
-		$orderby = ( ! empty( $_GET['orderby'] ) ) ? $_GET['orderby'] : 'id';
+		$orderby = ( ! empty( $_GET['orderby'] ) ) ? $_GET['orderby'] : 'position';
 		$order   = ( ! empty( $_GET['order'] ) ) ? strtolower( $_GET['order'] ) : 'desc';
 
 		if ( ! in_array( $orderby, array_keys( $sortable ) ) )
-			$orderby = 'id';
+			$orderby = 'position';
 
 		if ( ! in_array( $order, array( 'asc', 'desc' ) ) )
 			$order = 'desc';

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -260,6 +260,7 @@ class Red_Item {
 			$this->regex = isset( $details['regex'] ) ? 1 : 0;
 			$this->url   = self::sanitize_url( $details['old'], $this->regex );
 			$this->title = $details['title'];
+			$this->position = $details['position'];
 
 			$data = $this->match->data( $details );
 
@@ -274,7 +275,7 @@ class Red_Item {
 			}
 
 			// Save this
-			$wpdb->update( $wpdb->prefix.'redirection_items', array( 'url' => $this->url, 'regex' => $this->regex, 'action_code' => $this->action_code, 'action_data' => $data, 'group_id' => $this->group_id, 'title' => $this->title ), array( 'id' => $this->id ) );
+			$wpdb->update( $wpdb->prefix.'redirection_items', array( 'url' => $this->url, 'regex' => $this->regex, 'action_code' => $this->action_code, 'action_data' => $data, 'group_id' => $this->group_id, 'title' => $this->title, 'position' => $this->position ), array( 'id' => $this->id ) );
 
 			if ( $old_group !== $this->group_id ) {
 				Red_Module::flush( $this->group_id );

--- a/view/item-edit.php
+++ b/view/item-edit.php
@@ -22,6 +22,12 @@
 			</select>
 		</td>
 	</tr>
+	<tr class="advanced">
+		<th width="100"><?php _e( 'Position', 'redirection' ); ?>:</th>
+		<td>
+			<input style="width: 95%" type="text" name="position" value="<?php echo esc_attr( $redirect->get_position() ); ?>"/>
+		</td>
+	</tr>
 
 	<?php $redirect->match->show(); ?>
 


### PR DESCRIPTION
Modified item-edit.php and redirect.php to allow direct setting of "position" property under advanced settings.

Modified pager.php to order Redirect rules by position descending (same as order they execute in).

Why?

This eases creation of complex Regex rules, such as ones created during migration from one platform to another. If you add rules:

a/b/.*
a/.*

The order of the rules will determine which one gets executed for "a/b/c".
