### PR TITLE
Check existence of $group before using it (add.php)

### DIFF
--- a/view/add.php
+++ b/view/add.php
@@ -36,7 +36,7 @@
 				<th><?php _e( 'Group', 'redirection' ); ?>:</th>
 				<td>
 					<select name="group_id">
-						<?php echo $this->select( Red_Group::get_for_select(), $group )?>
+						<?php echo $this->select( Red_Group::get_for_select(), (isset($group) ? $group : '') )?>
 					</select>
 				</td>
 			</tr>


### PR DESCRIPTION
This prevents a notice message in a development environment - which will break the drop down when creating a redirect from a 404