### PR TITLE
Update values 255 and 200 over to 191

### DIFF
--- a/models/database.php
+++ b/models/database.php
@@ -35,7 +35,7 @@ class RE_Database {
 			  `match_type` varchar(20) NOT NULL,
 			  `title` varchar(50) NULL,
 			  PRIMARY KEY ( `id`),
-				KEY `url` (`url`(200)),
+				KEY `url` (`url`(191)),
 			  KEY `status` (`status`),
 			  KEY `regex` (`regex`),
 				KEY `group_idpos` (`group_id`,`position`),
@@ -76,9 +76,9 @@ class RE_Database {
 			"CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_404` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			  `created` datetime NOT NULL,
-			  `url` varchar(255) NOT NULL DEFAULT '',
-			  `agent` varchar(255) DEFAULT NULL,
-			  `referrer` varchar(255) DEFAULT NULL,
+			  `url` varchar(191) NOT NULL DEFAULT '',
+			  `agent` varchar(191) DEFAULT NULL,
+			  `referrer` varchar(191) DEFAULT NULL,
 			  `ip` int(10) unsigned NOT NULL,
 			  PRIMARY KEY (`id`),
 			  KEY `created` (`created`),
@@ -156,9 +156,9 @@ class RE_Database {
 		$wpdb->query( "CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_404` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			  `created` datetime NOT NULL,
-			  `url` varchar(255) NOT NULL DEFAULT '',
-			  `agent` varchar(255) DEFAULT NULL,
-			  `referrer` varchar(255) DEFAULT NULL,
+			  `url` varchar(191) NOT NULL DEFAULT '',
+			  `agent` varchar(191) DEFAULT NULL,
+			  `referrer` varchar(191) DEFAULT NULL,
 			  `ip` int(10) unsigned NOT NULL,
 			  PRIMARY KEY (`id`),
 			  KEY `created` (`created`),
@@ -200,7 +200,7 @@ class RE_Database {
 
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(module_id)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(status)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(url(200))" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(url(191))" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(status)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(regex)" );
 	}


### PR DESCRIPTION
This fixes issues with InnoDB utf8mb4 per the following upgrade: [https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/](https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/) so after that upgrade, whenever you create a new blog the database schema comes with utf8mb4 set.

InnoDB has a maximum index length of 767 bytes for tables that use a COMPACT or REDUNDANT row format, so for utf8 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. If you currently have utf8 columns with indexes longer than 191 characters, you will need to index a smaller number of characters.

Since the values on this value come with values greater than **191**, such tables fail to create hence the errors on the logs.
