### PR TITLE
do not cache 307 redirects when used on public hosting...

### DIFF
--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -105,6 +105,7 @@ class WordPress_Module extends Red_Module {
 		elseif ( $status == 307) {
 			status_header( $status );
 			header( "Cache-Control: no-cache, must-revalidate, max-age=0" );
+			header( "Expires: Sat, 26 Jul 1997 05:00:00 GMT" );
 			return $url;
 		}
 		status_header( $status );

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -103,9 +103,9 @@ class WordPress_Module extends Red_Module {
 			}
 		}
 		elseif ( $status == 307) {
-		status_header( $status );
-		header( "Cache-Control: no-cache, must-revalidate, max-age=0" );
-		return $url;
+			status_header( $status );
+			header( "Cache-Control: no-cache, must-revalidate, max-age=0" );
+			return $url;
 		}
 		status_header( $status );
 		return $url;

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -102,7 +102,11 @@ class WordPress_Module extends Red_Module {
 				}
 			}
 		}
-
+		elseif ( $status == 307) {
+		status_header( $status );
+		header( "Cache-Control: no-cache, must-revalidate, max-age=0" );
+		return $url;
+		}
 		status_header( $status );
 		return $url;
 	}


### PR DESCRIPTION
…with default varnish cache. allows for proper logging of redirects.
