### PR TITLE
Fix DB installation and update

### DIFF
--- a/models/database.php
+++ b/models/database.php
@@ -125,13 +125,17 @@ class RE_Database {
 	public function install() {
 		global $wpdb;
 
+		$wpdb->show_errors();
+
 		foreach ( $this->get_all_tables() as $sql ) {
 			if ( $wpdb->query( $sql ) === false ) {
+				throw new Exception( 'There was a database error installing Redirection - please post these details to https://github.com/johngodley/redirection/issues' );
 				return false;
 			}
 		}
 
 		$this->createDefaults();
+		$wpdb->hide_errors();
 
 		return true;
 	}

--- a/models/database.php
+++ b/models/database.php
@@ -1,109 +1,139 @@
 <?php
 
 class RE_Database {
-	private function get_charset() {
+	public function get_charset() {
 		global $wpdb;
 
 		$charset_collate = '';
-		if ( ! empty( $wpdb->charset ) )
+		if ( ! empty( $wpdb->charset ) ) {
 			$charset_collate = "DEFAULT CHARACTER SET $wpdb->charset";
+		}
 
-		if ( ! empty( $wpdb->collate ) )
-			$charset_collate .= " COLLATE $wpdb->collate";
+		if ( ! empty( $wpdb->collate ) ) {
+			$charset_collate .= " COLLATE=$wpdb->collate";
+		}
 
 		return $charset_collate;
+	}
+
+	private function create_items_sql( $prefix, $charset_collate ) {
+		return "CREATE TABLE IF NOT EXISTS `{$prefix}redirection_items` (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`url` mediumtext NOT NULL,
+			`regex` int(11) unsigned NOT NULL DEFAULT '0',
+			`position` int(11) unsigned NOT NULL DEFAULT '0',
+			`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+			`last_access` datetime NOT NULL,
+			`group_id` int(11) NOT NULL DEFAULT '0',
+			`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+			`action_type` varchar(20) NOT NULL,
+			`action_code` int(11) unsigned NOT NULL,
+			`action_data` mediumtext,
+			`match_type` varchar(20) NOT NULL,
+			`title` varchar(50) DEFAULT NULL,
+			PRIMARY KEY (`id`),
+			KEY `url` (`url`(191)),
+			KEY `status` (`status`),
+			KEY `regex` (`regex`),
+			KEY `group_idpos` (`group_id`,`position`),
+			KEY `group` (`group_id`)
+	  ) $charset_collate";
+	}
+
+	private function create_groups_sql( $prefix, $charset_collate ) {
+		return "CREATE TABLE IF NOT EXISTS `{$prefix}redirection_groups` (
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`name` varchar(50) NOT NULL,
+			`tracking` int(11) NOT NULL DEFAULT '1',
+			`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+			`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+			`position` int(11) unsigned NOT NULL DEFAULT '0',
+			PRIMARY KEY (`id`),
+			KEY `module_id` (`module_id`),
+			KEY `status` (`status`)
+		) $charset_collate";
+	}
+
+	private function create_log_sql( $prefix, $charset_collate ) {
+		return "CREATE TABLE IF NOT EXISTS `{$prefix}redirection_logs` (
+		  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+		  `created` datetime NOT NULL,
+		  `url` mediumtext NOT NULL,
+		  `sent_to` mediumtext,
+		  `agent` mediumtext NOT NULL,
+		  `referrer` mediumtext,
+		  `redirection_id` int(11) unsigned DEFAULT NULL,
+		  `ip` varchar(17) NOT NULL DEFAULT '',
+		  `module_id` int(11) unsigned NOT NULL,
+		  `group_id` int(11) unsigned DEFAULT NULL,
+		  PRIMARY KEY (`id`),
+		  KEY `created` (`created`),
+		  KEY `redirection_id` (`redirection_id`),
+		  KEY `ip` (`ip`),
+		  KEY `group_id` (`group_id`),
+		  KEY `module_id` (`module_id`)
+	  	) $charset_collate";
+	}
+
+	private function create_404_sql( $prefix, $charset_collate ) {
+		return "CREATE TABLE IF NOT EXISTS `{$prefix}redirection_404` (
+		  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+		  `created` datetime NOT NULL,
+		  `url` varchar(255) NOT NULL DEFAULT '',
+		  `agent` varchar(255) DEFAULT NULL,
+		  `referrer` varchar(255) DEFAULT NULL,
+		  `ip` int(10) unsigned NOT NULL,
+		  PRIMARY KEY (`id`),
+		  KEY `created` (`created`),
+		  KEY `url` (`url`(191)),
+		  KEY `ip` (`ip`),
+		  KEY `referrer` (`referrer`(191))
+	  	) $charset_collate";
+	}
+
+	public function get_all_tables() {
+		global $wpdb;
+
+		$charset_collate = $this->get_charset();
+
+		return array(
+			"{$wpdb->prefix}redirection_items" => $this->create_items_sql( $wpdb->prefix, $charset_collate ),
+			"{$wpdb->prefix}redirection_groups" => $this->create_groups_sql( $wpdb->prefix, $charset_collate ),
+			"{$wpdb->prefix}redirection_logs" => $this->create_log_sql( $wpdb->prefix, $charset_collate ),
+			"{$wpdb->prefix}redirection_404" => $this->create_404_sql( $wpdb->prefix, $charset_collate ),
+		);
+	}
+
+	public function createDefaults() {
+		$this->createDefaultGroups();
+
+		update_option( 'redirection_version', REDIRECTION_VERSION );
+	}
+
+	private function createDefaultGroups() {
+		global $wpdb;
+
+		$existing_groups = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_groups" );
+
+		// Default groups
+		if ( intval( $existing_groups, 10 ) === 0 ) {
+			$wpdb->insert( $wpdb->prefix.'redirection_groups', array( 'name' => __( 'Redirections' ), 'module_id' => 1, 'position' => 0 ) );
+			$wpdb->insert( $wpdb->prefix.'redirection_groups', array( 'name' => __( 'Modified Posts' ), 'module_id' => 1, 'position' => 1 ) );
+		}
 	}
 
 	public function install() {
 		global $wpdb;
 
-		$charset_collate = $this->get_charset();
-
-		$create = array(
-			"CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_items`(
-				`id` int(11) unsigned NOT NULL auto_increment,
-			  `url` mediumtext NOT NULL,
-			  `regex` int(11) unsigned NOT NULL default '0',
-			  `position` int(11) unsigned NOT NULL default '0',
-			  `last_count` int(10) unsigned NOT NULL default '0',
-			  `last_access` datetime NOT NULL,
-			  `group_id` int(11) NOT NULL default '0',
-			  `status` enum('enabled','disabled' ) NOT NULL default 'enabled',
-			  `action_type` varchar(20) NOT NULL,
-			  `action_code` int(11) unsigned NOT NULL,
-			  `action_data` mediumtext,
-			  `match_type` varchar(20) NOT NULL,
-			  `title` varchar(50) NULL,
-			  PRIMARY KEY ( `id`),
-				KEY `url` (`url`(200)),
-			  KEY `status` (`status`),
-			  KEY `regex` (`regex`),
-				KEY `group_idpos` (`group_id`,`position`),
-			  KEY `group` (`group_id`)
-			) $charset_collate",
-
-			"CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_groups`(
-			  `id` int(11) NOT NULL auto_increment,
-			  `name` varchar(50) NOT NULL,
-			  `tracking` int(11) NOT NULL default '1',
-			  `module_id` int(11) unsigned NOT NULL default '0',
-		  	`status` enum('enabled','disabled' ) NOT NULL default 'enabled',
-		  	`position` int(11) unsigned NOT NULL default '0',
-			  PRIMARY KEY ( `id`),
-				KEY `module_id` (`module_id`),
-		  	KEY `status` (`status`)
-			) $charset_collate",
-
-			"CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_logs`(
-			  `id` int(11) unsigned NOT NULL auto_increment,
-			  `created` datetime NOT NULL,
-			  `url` mediumtext NOT NULL,
-			  `sent_to` mediumtext,
-			  `agent` mediumtext NOT NULL,
-			  `referrer` mediumtext,
-			  `redirection_id` int(11) unsigned default NULL,
-			  `ip` varchar(17) NOT NULL default '',
-			  `module_id` int(11) unsigned NOT NULL,
-				`group_id` int(11) unsigned default NULL,
-			  PRIMARY KEY ( `id`),
-			  KEY `created` (`created`),
-			  KEY `redirection_id` (`redirection_id`),
-			  KEY `ip` (`ip`),
-			  KEY `group_id` (`group_id`),
-			  KEY `module_id` (`module_id`)
-			) $charset_collate",
-
-			"CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_404` (
-			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-			  `created` datetime NOT NULL,
-			  `url` varchar(255) NOT NULL DEFAULT '',
-			  `agent` varchar(255) DEFAULT NULL,
-			  `referrer` varchar(255) DEFAULT NULL,
-			  `ip` int(10) unsigned NOT NULL,
-			  PRIMARY KEY (`id`),
-			  KEY `created` (`created`),
-			  KEY `url` (`url`),
-			  KEY `ip` (`ip`),
-			  KEY `referrer` (`referrer`)
-		  	) $charset_collate;",
-		);
-
-		foreach ( $create as $sql ) {
-			if ( $wpdb->query( $sql ) === false )
+		foreach ( $this->get_all_tables() as $sql ) {
+			if ( $wpdb->query( $sql ) === false ) {
 				return false;
+			}
 		}
 
-		// Groups
-		if ( intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_groups", 10 ) ) === 0 ) {
-			$wpdb->insert( $wpdb->prefix.'redirection_groups', array( 'name' => __( 'Redirections' ), 'module_id' => 1, 'position' => 0 ) );
-			$wpdb->insert( $wpdb->prefix.'redirection_groups', array( 'name' => __( 'Modified Posts' ), 'module_id' => 1, 'position' => 1 ) );
+		$this->createDefaults();
 
-			$options = get_option( 'redirection_options' );
-			$options['monitor_post']     = 2;
-			$options['monitor_category'] = 2;
-
-			update_option( 'redirection_options', $options );
-		}
+		return true;
 	}
 
 	public function upgrade( $current, $target ) {
@@ -111,126 +141,110 @@ class RE_Database {
 
 		$wpdb->show_errors();
 
-		// No previous version? Install the DB tables
-		if ( $current === false )
-			$success = $this->install();
-		else {
-			// Try and upgrade from a previous version
-			if ( $current === '2.0' )
-				$this->upgrade_from_20();
-			elseif ( $current === '2.0.1' )
-				$this->upgrade_from_21();
-			elseif ( $current === '2.0.2' )
-				$this->upgrade_from_22();
+		if ( $current !== false ) {
+			$versions = array(
+				'2.0.1'  => 'upgrade_to_201',
+				'2.1.16' => 'upgrade_to_216',
+				'2.2'    => 'upgrade_to_220',
+				'2.3.1'  => 'upgrade_to_231',
+				'2.3.2'  => 'upgrade_to_232',
+				'2.3.3'  => 'upgrade_to_233',
+			);
 
-			if ( version_compare( $current, '2.1.16' ) === -1 )
-				$this->upgrade_to_216();
+			foreach ( $versions AS $vers => $upgrade ) {
+				if ( version_compare( $current, $vers ) === -1 ) {
+					$this->$upgrade();
+				}
+			}
 
-			if ( version_compare( $current, '2.2' ) === -1 )
-				$this->upgrade_to_220();
-
-			if ( version_compare( $current, '2.3.1' ) === -1 )
-				$this->upgrade_to_231();
-
-			if ( version_compare( $current, '2.3.2' ) === -1 )
-				$this->upgrade_to_232();
-
-			$success = true;
+			update_option( 'redirection_version', $target );
 		}
 
-		// Set our current version
-		update_option( 'redirection_version', $target );
-
 		$wpdb->hide_errors();
-		return $success;
 	}
 
-	private function upgrade_to_231() {
+	/**
+	 * 2.32 => 2.3.3
+	 * Migrate any groups with incorrect module_ids
+	 * Create a group if none exists
+	 */
+	private function upgrade_to_233() {
 		global $wpdb;
 
-		$charset_collate = $this->get_charset();
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_modules WHERE type='404'" );
-		$wpdb->query( "UPDATE {$wpdb->prefix}redirection_groups SET module_id=1 WHERE module_id=3" );
-
-		$wpdb->query( "CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}redirection_404` (
-			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-			  `created` datetime NOT NULL,
-			  `url` varchar(255) NOT NULL DEFAULT '',
-			  `agent` varchar(255) DEFAULT NULL,
-			  `referrer` varchar(255) DEFAULT NULL,
-			  `ip` int(10) unsigned NOT NULL,
-			  PRIMARY KEY (`id`),
-			  KEY `created` (`created`),
-			  KEY `url` (`url`),
-  			  KEY `ip` (`ip`,`id`),
-			  KEY `referrer` (`referrer`)
-			) $charset_collate;" );
+		$wpdb->query( "UPDATE {$wpdb->prefix}redirection_groups SET module_id=1 WHERE module_id > 2" );
+		$this->createDefaultGroups();
 	}
 
+	/**
+	 * 2.3.1 => 2.3.2
+	 * Delete the redirection_modules table
+	 */
 	private function upgrade_to_232() {
 		global $wpdb;
 
 		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_modules;" );
 	}
 
-	private function upgrade_from_20() {
+	/**
+	 * 2.2 => 2.3.1
+	 * Update any group referring to 404 module to WordPress module
+	 * Create 404 log table
+	 */
+	private function upgrade_to_231() {
 		global $wpdb;
 
-		$this->upgrade_from_21();
-		$this->upgrade_from_22();
+		$wpdb->query( "UPDATE {$wpdb->prefix}redirection_groups SET module_id=1 WHERE module_id=3" );
+		$wpdb->query( $this->create_404_sql( $wpdb->prefix, $this->get_charset() ) );
 	}
 
-	private function upgrade_from_21() {
-		global $wpdb;
-
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD `title` varchar(50) NULL" );
-
-		$this->upgrade_from_22();
-	}
-
-	private function upgrade_from_22() {
-		global $wpdb;
-
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` CHANGE `title` `title` varchar(50) NULL" );
-	}
-
-	private function upgrade_to_216() {
-		global $wpdb;
-
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(module_id)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(status)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(url(200))" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(status)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(regex)" );
-	}
-
+	/**
+	 * 2.1.6 => 2.2.0
+	 * Add indices to redirection items and logs
+	 */
 	private function upgrade_to_220() {
 		global $wpdb;
 
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX `group_idpos` (`group_id`,`position`)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX `group` (`group_id`)" );
-
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `group` (`group_id`)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `redirection_id` (`redirection_id`)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `created` (`created`)" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `redirection_id` (`redirection_id`)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `ip` (`ip`)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `group_id` (`group_id`)" );
 		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_logs` ADD INDEX `module_id` (`module_id`)" );
-
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_modules` ADD INDEX `name` (`name`)" );
-		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_modules` ADD INDEX `type` (`type`)" );
 	}
 
-	public function remove( $plugin ) {
+	/**
+	 * 2.0.1 => 2.1.6
+	 * Update any group referring to 404 module to WordPress module
+	 * Create 404 log table
+	 */
+	private function upgrade_to_216() {
 		global $wpdb;
 
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection;" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_items;" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_logs;" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_groups;" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_modules;" );
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_404;" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(module_id)" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_groups` ADD INDEX(status)" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(url(191))" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(status)" );
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD INDEX(regex)" );
+	}
+
+	/**
+	 * <2.0.1 => 2.0.1
+	 */
+	private function upgrade_to_201() {
+		global $wpdb;
+
+		$wpdb->query( "ALTER TABLE `{$wpdb->prefix}redirection_items` ADD `title` varchar(50) NULL" );
+	}
+
+	public function remove() {
+		global $wpdb;
+
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_items" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_logs" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_groups" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_modules" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_404" );
 
 		delete_option( 'redirection_lookup' );
 		delete_option( 'redirection_post' );

--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -109,6 +109,11 @@ class Redirection_Admin {
 			include_once dirname( REDIRECTION_FILE ).'/models/database.php';
 
 			$database = new RE_Database();
+
+			if ( $version === false ) {
+				$database->install();
+			}
+
 			return $database->upgrade( $version, REDIRECTION_VERSION );
 		}
 

--- a/redirection.php
+++ b/redirection.php
@@ -21,7 +21,7 @@ For full license details see license.txt
 ============================================================================================================
 */
 
-define( 'REDIRECTION_VERSION', '2.3.2' );     // DB schema version. Only change if DB needs changing
+define( 'REDIRECTION_VERSION', '2.3.3' );     // DB schema version. Only change if DB needs changing
 define( 'REDIRECTION_FILE', __FILE__ );
 
 include dirname( __FILE__ ).'/models/module.php';

--- a/tests/models/sql/2.0.0.sql
+++ b/tests/models/sql/2.0.0.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_modules` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `type` varchar(20) NOT NULL default '',
+  `name` varchar(50) NOT NULL default '',
+  `options` mediumtext,
+  PRIMARY KEY ( `id`),
+  KEY `name` (`name`),
+  KEY `type` (`type`)
+);

--- a/tests/models/sql/2.1.15.sql
+++ b/tests/models/sql/2.1.15.sql
@@ -1,0 +1,50 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	`title` varchar(50) DEFAULT NULL,
+	PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_modules` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `type` varchar(20) NOT NULL default '',
+  `name` varchar(50) NOT NULL default '',
+  `options` mediumtext,
+  PRIMARY KEY ( `id`),
+  KEY `name` (`name`),
+  KEY `type` (`type`)
+);

--- a/tests/models/sql/2.1.19.sql
+++ b/tests/models/sql/2.1.19.sql
@@ -1,0 +1,55 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	`title` varchar(50) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `url` (`url`(191)),
+	KEY `status` (`status`),
+	KEY `regex` (`regex`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`),
+	KEY `module_id` (`module_id`),
+	KEY `status` (`status`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `{$prefix}redirection_modules` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `type` varchar(20) NOT NULL default '',
+  `name` varchar(50) NOT NULL default '',
+  `options` mediumtext,
+  PRIMARY KEY ( `id`),
+  KEY `name` (`name`),
+  KEY `type` (`type`)
+);

--- a/tests/models/sql/2.3.0.sql
+++ b/tests/models/sql/2.3.0.sql
@@ -1,0 +1,64 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	`title` varchar(50) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `url` (`url`(191)),
+	KEY `status` (`status`),
+	KEY `regex` (`regex`),
+	KEY `group_idpos` (`group_id`,`position`),
+	KEY `group` (`group_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`),
+	KEY `module_id` (`module_id`),
+	KEY `status` (`status`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `created` (`created`),
+  KEY `redirection_id` (`redirection_id`),
+  KEY `ip` (`ip`),
+  KEY `group_id` (`group_id`),
+  KEY `module_id` (`module_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_modules` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `type` varchar(20) NOT NULL default '',
+  `name` varchar(50) NOT NULL default '',
+  `options` mediumtext,
+  PRIMARY KEY ( `id`),
+  KEY `name` (`name`),
+  KEY `type` (`type`)
+);
+
+INSERT INTO {$prefix}redirection_groups (module_id) VALUES(3);

--- a/tests/models/sql/2.3.1.sql
+++ b/tests/models/sql/2.3.1.sql
@@ -1,0 +1,76 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	`title` varchar(50) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `url` (`url`(191)),
+	KEY `status` (`status`),
+	KEY `regex` (`regex`),
+	KEY `group_idpos` (`group_id`,`position`),
+	KEY `group` (`group_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`),
+	KEY `module_id` (`module_id`),
+	KEY `status` (`status`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `created` (`created`),
+  KEY `redirection_id` (`redirection_id`),
+  KEY `ip` (`ip`),
+  KEY `group_id` (`group_id`),
+  KEY `module_id` (`module_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_404` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` varchar(255) NOT NULL DEFAULT '',
+  `agent` varchar(255) DEFAULT NULL,
+  `referrer` varchar(255) DEFAULT NULL,
+  `ip` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `created` (`created`),
+  KEY `url` (`url`(191)),
+  KEY `ip` (`ip`),
+  KEY `referrer` (`referrer`(191))
+);
+
+CREATE TABLE `{$prefix}redirection_modules` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `type` varchar(20) NOT NULL default '',
+  `name` varchar(50) NOT NULL default '',
+  `options` mediumtext,
+  PRIMARY KEY ( `id`),
+  KEY `name` (`name`),
+  KEY `type` (`type`)
+);

--- a/tests/models/sql/2.3.2.sql
+++ b/tests/models/sql/2.3.2.sql
@@ -1,0 +1,66 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext NOT NULL,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL,
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext,
+	`match_type` varchar(20) NOT NULL,
+	`title` varchar(50) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `url` (`url`(191)),
+	KEY `status` (`status`),
+	KEY `regex` (`regex`),
+	KEY `group_idpos` (`group_id`,`position`),
+	KEY `group` (`group_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`),
+	KEY `module_id` (`module_id`),
+	KEY `status` (`status`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` mediumtext NOT NULL,
+  `sent_to` mediumtext,
+  `agent` mediumtext NOT NULL,
+  `referrer` mediumtext,
+  `redirection_id` int(11) unsigned DEFAULT NULL,
+  `ip` varchar(17) NOT NULL DEFAULT '',
+  `module_id` int(11) unsigned NOT NULL,
+  `group_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `created` (`created`),
+  KEY `redirection_id` (`redirection_id`),
+  KEY `ip` (`ip`),
+  KEY `group_id` (`group_id`),
+  KEY `module_id` (`module_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_404` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL,
+  `url` varchar(255) NOT NULL DEFAULT '',
+  `agent` varchar(255) DEFAULT NULL,
+  `referrer` varchar(255) DEFAULT NULL,
+  `ip` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `created` (`created`),
+  KEY `url` (`url`(191)),
+  KEY `ip` (`ip`),
+  KEY `referrer` (`referrer`(191))
+);

--- a/tests/models/test-database.php
+++ b/tests/models/test-database.php
@@ -186,19 +186,17 @@ class DatabaseTest extends WP_UnitTestCase {
 
 		$database = new RE_Database();
 
-		foreach ( $database->get_all_tables() as $table => $sql ) {
-			$create = $this->getCreateTable( $table );
+		foreach ( $database->get_all_tables() as $table => $expected ) {
+			$actual = $this->getCreateTable( $table );
+			$actual = preg_replace( '/^\s+/m', '', $actual );
+			$actual = preg_replace( '/\s?COLLATE \w*/', '', $actual );
+			$actual = preg_replace( '/\).*?$/', ') '.$database->get_charset(), $actual );
 
 			// 'massage' all the SQL so we can try and match it
-			$create = preg_replace( '/^\s+/m', '', $create );
-			$sql = preg_replace( '/^\s+/m', '', $sql );
-			$sql = str_replace( 'IF NOT EXISTS ', '', $sql );
-			$sql = str_replace( 'DEFAULT CHARACTER SET utf8mb4 ', '', $sql );
-			$create = str_replace( 'COLLATE utf8mb4_unicode_ci ', '', $create );
-			$create = str_replace( ' COLLATE utf8mb4_unicode_ci,', ',', $create );
-			$create = preg_replace( '/ENGINE=.*? DEFAULT CHARSET=.*? /', '', $create );
+			$expected = preg_replace( '/^\s+/m', '', $expected );
+			$expected = str_replace( 'IF NOT EXISTS ', '', $expected );
 
-			$this->assertEquals( $sql, $create, 'Database table for '.$version.' '.$table.' does not match' );
+			$this->assertEquals( $expected, $actual, 'Database table for '.$version.' '.$table.' does not match' );
 		}
 
 		// Check deleted tables don't exist

--- a/tests/models/test-database.php
+++ b/tests/models/test-database.php
@@ -1,0 +1,247 @@
+<?php
+
+class DatabaseTest extends WP_UnitTestCase {
+	private $previous_prefix;
+
+	private function removeTables() {
+		global $wpdb;
+
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_items" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_logs" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_groups" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}redirection_404" );
+	}
+
+	private function checkTableExists( $table ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix.$table;
+		$exists = $wpdb->get_results( $wpdb->prepare( "SHOW TABLES LIKE %s", $table ) );
+
+		return count( $exists ) === 1;
+	}
+
+	private function getCreateTable( $table ) {
+		global $wpdb;
+
+		$create = 'Create Table';
+		$result = $wpdb->get_row( "SHOW CREATE TABLE $table" );
+
+		return $result->$create;
+	}
+
+	public function setUp() {
+		global $wpdb;
+
+		$this->previous_prefix = $wpdb->prefix;
+		$wpdb->prefix = 'dbtest_';
+
+		$this->removeTables();
+	}
+
+	public function tearDown() {
+		global $wpdb;
+
+		$this->removeTables();
+
+		$wpdb->prefix = $this->previous_prefix;
+	}
+
+	public function testNothing() {
+		$this->assertFalse( $this->checkTableExists( 'redirection_items' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_groups' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_logs' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_404' ) );
+	}
+
+	public function testInstallClean() {
+		$database = new RE_Database();
+		$database->install();
+
+		$this->assertTrue( $this->checkTableExists( 'redirection_items' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_groups' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_logs' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_404' ) );
+	}
+
+	public function testInstallExisting() {
+		$database = new RE_Database();
+		$database->install();
+		$database->install();
+
+		$this->assertTrue( $this->checkTableExists( 'redirection_items' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_groups' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_logs' ) );
+		$this->assertTrue( $this->checkTableExists( 'redirection_404' ) );
+	}
+
+	public function testRemove() {
+		add_option( 'redirection_lookup', 'test' );
+		add_option( 'redirection_post', 'test' );
+		add_option( 'redirection_root', 'test' );
+		add_option( 'redirection_index', 'test' );
+		add_option( 'redirection_version', 'test' );
+
+		$database = new RE_Database();
+		$database->install();
+		$database->remove();
+
+		$this->assertFalse( $this->checkTableExists( 'redirection_items' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_groups' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_logs' ) );
+		$this->assertFalse( $this->checkTableExists( 'redirection_404' ) );
+
+		$this->assertFalse( get_option( 'redirection_lookup' ) );
+		$this->assertFalse( get_option( 'redirection_post' ) );
+		$this->assertFalse( get_option( 'redirection_root' ) );
+		$this->assertFalse( get_option( 'redirection_index' ) );
+		$this->assertFalse( get_option( 'redirection_version' ) );
+	}
+
+	public function testDefaultGroupsClean() {
+		global $wpdb;
+
+		$database = new RE_Database();
+		$database->install();
+
+		$groups = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_groups" );
+		$this->assertEquals( count( $groups ), 2 );
+	}
+
+	public function testDefaultGroupsExisting() {
+		global $wpdb;
+
+		$database = new RE_Database();
+		$database->install();
+		$database->createDefaults();
+
+		$groups = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_groups" );
+		$this->assertEquals( count( $groups ), 2 );
+	}
+
+	public function testVersion() {
+		$database = new RE_Database();
+		$database->install();
+		$this->assertEquals( REDIRECTION_VERSION, get_option( 'redirection_version' ) );
+	}
+
+	public function testUpgradeSameVersion() {
+		$database = new RE_Database();
+		$database->install();
+		$database->upgrade( REDIRECTION_VERSION, REDIRECTION_VERSION );
+
+		$this->assertEquals( REDIRECTION_VERSION, get_option( 'redirection_version' ) );
+	}
+
+	public function testUpgradeVersion() {
+		$database = new RE_Database();
+		$database->install();
+		$database->upgrade( REDIRECTION_VERSION, 10.1 );
+
+		$this->assertEquals( '10.1', get_option( 'redirection_version' ) );
+	}
+
+	private function sqlClean( $sql ) {
+		global $wpdb;
+
+		$database = new RE_Database();
+
+		$sql = str_replace( '{$prefix}', $wpdb->prefix, $sql );
+		$sql = trim( $sql );
+
+		if ( strlen( $sql ) > 0 && strpos( $sql, 'CREATE TABLE' ) !== false ) {
+			$sql .= ' '.$database->get_charset();
+		}
+
+		return $sql;
+	}
+
+	private function loadSql( $file ) {
+		$file = file_get_contents( $file );
+		if ( $file ) {
+			return array_filter( array_map( array( $this, 'sqlClean' ), explode( ';', $file ) ) );
+		}
+
+		return false;
+	}
+
+	private function createTables( $file ) {
+		global $wpdb;
+
+		$sql = $this->loadSql( $file );
+
+		if ( $sql ) {
+			foreach ( $sql as $table ) {
+				$wpdb->query( $table );
+			}
+
+			return true;
+		}
+
+		$this->fail( 'Missing table: '.$file );
+	}
+
+	private function checkAgainstLatest( $version ) {
+		global $wpdb;
+
+		$database = new RE_Database();
+
+		foreach ( $database->get_all_tables() as $table => $sql ) {
+			$create = $this->getCreateTable( $table );
+
+			// 'massage' all the SQL so we can try and match it
+			$create = preg_replace( '/^\s+/m', '', $create );
+			$sql = preg_replace( '/^\s+/m', '', $sql );
+			$sql = str_replace( 'IF NOT EXISTS ', '', $sql );
+			$sql = str_replace( 'DEFAULT CHARACTER SET utf8mb4 ', '', $sql );
+			$create = str_replace( 'COLLATE utf8mb4_unicode_ci ', '', $create );
+			$create = str_replace( ' COLLATE utf8mb4_unicode_ci,', ',', $create );
+			$create = preg_replace( '/ENGINE=.*? DEFAULT CHARSET=.*? /', '', $create );
+
+			$this->assertEquals( $sql, $create, 'Database table for '.$version.' '.$table.' does not match' );
+		}
+
+		// Check deleted tables don't exist
+		$this->assertFalse( $this->checkTableExists( 'redirection_modules' ), 'Modules table still exists' );
+
+		// Other checks for converted rows
+		$this->assertEquals( 0, intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_groups WHERE module_id=3" ), 10 ) );
+		$this->assertTrue( intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_groups" ), 10 ) > 0 );
+	}
+
+	public function testUpgradeFromLatest() {
+		// Perform upgrade to latest
+		$database = new RE_Database();
+		$database->install();
+		$database->upgrade( REDIRECTION_VERSION, REDIRECTION_VERSION );
+
+		// Check tables match latest
+		$this->checkAgainstLatest( REDIRECTION_VERSION );
+	}
+
+	public function testUpgradeFromOlder() {
+		$versions = array(
+			'2.3.2',
+			'2.3.1',
+			'2.3.0',
+			'2.1.19',
+			'2.1.15',
+			'2.0.0',
+		);
+
+		foreach ( $versions as $ver ) {
+			// Load old tables
+			$this->createTables( dirname( __FILE__ ).'/sql/'.$ver.'.sql' );
+
+			// Perform upgrade to latest
+			$database = new RE_Database();
+			$database->upgrade( $ver, REDIRECTION_VERSION );
+
+			// Check tables match latest
+			$this->checkAgainstLatest( $ver );
+
+			// Remove all evidence
+			$this->removeTables();
+		}
+	}
+}


### PR DESCRIPTION
Have it cascade through the versions until it reaches the current one.

Add a 2.3.2 upgrade that checks for missing groups and old module IDs - hopefully catch anyone’s installation that might have old data caused by previous bugs.

Fixes #102 
Fixes #123 
Fixes #95
