### PR TITLE
Do not wrap encode_from in ^ and $ if regex

### DIFF
--- a/models/htaccess.php
+++ b/models/htaccess.php
@@ -6,7 +6,7 @@ class Red_Htaccess {
 
 	private function encode_from( $url, $regex = false ) {
 		if ( $regex ) 
-			return $this->encode( $url )
+			return $this->encode( $url );
 		return '^'.$this->encode( $url ).'$';
 	}
 

--- a/models/htaccess.php
+++ b/models/htaccess.php
@@ -4,7 +4,9 @@ class Red_Htaccess {
 	private $items = array();
 	const INSERT_REGEX = '@\n?# Created by Redirection(.*?)# End of Redirection\n?@sm';
 
-	private function encode_from( $url ) {
+	private function encode_from( $url, $regex = false ) {
+		if ( $regex ) 
+			return $this->encode( $url )
 		return '^'.$this->encode( $url ).'$';
 	}
 
@@ -89,7 +91,7 @@ class Red_Htaccess {
 		}
 
 		$to   = $this->target( $item->get_action_type(), $match->url, $item->get_action_code(), $item->is_regex() );
-		$from = $this->encode_from( $url );
+		$from = $this->encode_from( $url, $item->is_regex() );
 
 		if ( $item->is_regex() )
 			$from = $this->encode_regex( $item->get_url() );


### PR DESCRIPTION
If the from url is a regex then we should not wrap the encoded string with beginning and end regex characters.

Note: I have not tested whether we should encode regex strings or not - but I suspect not. This needs knowledge about url encoding that I don't have in my head and don't have time to research and a decent set of test cases and testing.