### PR TITLE
Remove leading slash for Apache 2

### DIFF
--- a/tests/fileio/test-htaccess.php
+++ b/tests/fileio/test-htaccess.php
@@ -75,8 +75,26 @@ and a line at the end';
 		$file = $htaccess->get();
 		$lines = explode( "\n", $file );
 
-		$this->assertEquals( 'RewriteRule ^/my-test$  [R=301,L]', trim( $lines[5] ) );
-		$this->assertEquals( 'RewriteRule ^/my-test\.php$  [R=302,L]', trim( $lines[6] ) );
+		$this->assertEquals( 'RewriteRule ^my-test$  [R=301,L]', trim( $lines[5] ) );
+		$this->assertEquals( 'RewriteRule ^my-test\.php$  [R=302,L]', trim( $lines[6] ) );
+	}
+
+	public function testRedirectUrlRegex() {
+		$htaccess = new Red_Htaccess();
+		$htaccess->add( new Red_Item( (object)array( 'match_type' => 'url', 'id' => 1, 'action_type' => 'url', 'url' => '/my\.test.*?', 'action_code' => 301, 'regex' => true ) ) );
+		$file = $htaccess->get();
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( 'RewriteRule my\.test.*?  [R=301,L]', trim( $lines[5] ) );
+	}
+
+	public function testRedirectUrlRegexLimit() {
+		$htaccess = new Red_Htaccess();
+		$htaccess->add( new Red_Item( (object)array( 'match_type' => 'url', 'id' => 1, 'action_type' => 'url', 'url' => '^/my-test.*?$', 'action_code' => 301, 'regex' => true ) ) );
+		$file = $htaccess->get();
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( 'RewriteRule ^my-test.*?$  [R=301,L]', trim( $lines[5] ) );
 	}
 
 	public function testError() {
@@ -86,8 +104,8 @@ and a line at the end';
 		$file = $htaccess->get();
 		$lines = explode( "\n", $file );
 
-		$this->assertEquals( 'RewriteRule ^/my-test$ / [F]', trim( $lines[5] ) );
-		$this->assertEquals( 'RewriteRule ^/my-test\.php$ / [G]', trim( $lines[6] ) );
+		$this->assertEquals( 'RewriteRule ^my-test$ / [F]', trim( $lines[5] ) );
+		$this->assertEquals( 'RewriteRule ^my-test\.php$ / [G]', trim( $lines[6] ) );
 	}
 
 	public function testRedirectUrlWithQuery() {
@@ -98,9 +116,9 @@ and a line at the end';
 		$lines = explode( "\n", $file );
 
 		$this->assertEquals( 'RewriteCond %{QUERY_STRING} ^query=1$', trim( $lines[5] ) );
-		$this->assertEquals( 'RewriteRule ^/my-test$  [R=301,L]', trim( $lines[6] ) );
+		$this->assertEquals( 'RewriteRule ^my-test$  [R=301,L]', trim( $lines[6] ) );
 		$this->assertEquals( 'RewriteCond %{QUERY_STRING} ^query=1&thing=2$', trim( $lines[7] ) );
-		$this->assertEquals( 'RewriteRule ^/my-test\.php$  [R=302,L]', trim( $lines[8] ) );
+		$this->assertEquals( 'RewriteRule ^my-test\.php$  [R=302,L]', trim( $lines[8] ) );
 	}
 
 	public function testRedirectUrlWithTargetQuery() {
@@ -109,7 +127,7 @@ and a line at the end';
 		$file = $htaccess->get();
 		$lines = explode( "\n", $file );
 
-		$this->assertEquals( 'RewriteRule ^/my-test$ /target?test=1&test=2%20 [R=301,L]', trim( $lines[5] ) );
+		$this->assertEquals( 'RewriteRule ^my-test$ /target?test=1&test=2%20 [R=301,L]', trim( $lines[5] ) );
 	}
 
 	public function testInvalidRegex() {


### PR DESCRIPTION
Apache doesn't require a leading slash on the source URL so make sure we don't add it to the file.