### PR TITLE
Updated strings to use en_US by default

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -306,7 +306,7 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 = 2.1.24 =
 * Add Ukrainian translation
 * Add Polish translation
-* Database optimisation
+* Database optimization
 
 = 2.1.23 =
 * Add Bahasa Indonesian translation
@@ -357,7 +357,7 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 * Errors on some sites
 
 = 2.1.10 =
-* Missing localisations
+* Missing localizations
 
 = 2.1.9 =
 * Fix 'you do not permissions' error on some non-English sites


### PR DESCRIPTION
While doing en_CA translations I found two strings using the en_AU/en_GB version when it should be en_US by default.
Strings being;
localisations => localizations
optimisations => optimizations