### PR TITLE
Unify request info

### DIFF
--- a/models/redirect.php
+++ b/models/redirect.php
@@ -342,33 +342,9 @@ class Red_Item {
 
 			$options = red_get_options();
 			if ( isset( $options['expire_redirect'] ) && $options['expire_redirect'] >= 0 ) {
-				$log = RE_Log::create( $url, $target, $this->get_user_agent(), $this->get_ip(), $this->get_referrer(), array( 'redirect_id' => $this->id, 'group_id' => $this->group_id ) );
+				$log = RE_Log::create( $url, $target, Redirection_Request::get_user_agent(), Redirection_Request::get_ip(), Redirection_Request::get_referrer(), array( 'redirect_id' => $this->id, 'group_id' => $this->group_id ) );
 			}
 		}
-	}
-
-	private function get_ip() {
-		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) )
-			return $_SERVER['HTTP_X_FORWARDED_FOR'];
-		elseif ( isset( $_SERVER['REMOTE_ADDR'] ) )
-			return $_SERVER['REMOTE_ADDR'];
-		return '';
-	}
-
-	private function get_referrer() {
-		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
-			return $_SERVER['HTTP_REFERER'];
-		}
-
-		return '';
-	}
-
-	private function get_user_agent() {
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			return $_SERVER['HTTP_USER_AGENT'];
-		}
-
-		return '';
 	}
 
 	public function is_enabled() {

--- a/models/request.php
+++ b/models/request.php
@@ -1,0 +1,45 @@
+<?php
+
+class Redirection_Request {
+	public static function get_request_url() {
+		$url = '';
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$url = $_SERVER['REQUEST_URI'];
+		}
+
+		return apply_filters( 'redirection_request_url', $url );
+	}
+
+	public static function get_user_agent() {
+		$agent = '';
+
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$agent = $_SERVER['HTTP_USER_AGENT'];
+		}
+
+		return apply_filters( 'redirection_request_agent', $agent );
+	}
+
+	public static function get_referrer() {
+		$referrer = '';
+
+		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+			$referrer = $_SERVER['HTTP_REFERER'];
+		}
+
+		return apply_filters( 'redirection_request_referrer', $referrer );
+	}
+
+	public static function get_ip() {
+		$ip = '';
+
+		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+			$ip = $_SERVER['REMOTE_ADDR'];
+		}
+
+		return apply_filters( 'redirection_request_ip', $ip );
+	}
+}

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -62,7 +62,7 @@ class WordPress_Module extends Red_Module {
 			$options = red_get_options();
 
 			if ( isset( $options['expire_404'] ) && $options['expire_404'] >= 0 ) {
-				RE_404::create( $this->get_url(), $this->get_user_agent(), $this->get_ip(), $this->get_referrer() );
+				RE_404::create( Redirection_Request::get_request_url(), Redirection_Request::get_user_agent(), Redirection_Request::get_ip(), Redirection_Request::get_referrer() );
 			}
 		}
 	}
@@ -135,31 +135,5 @@ class WordPress_Module extends Red_Module {
 
 	public function get_description() {
 		return __( 'WordPress-powered redirects. This requires no further configuration, and you can track hits.', 'redirection' );
-	}
-
-	private function get_url() {
-		if ( isset( $_SERVER['REQUEST_URI'] ) )
-			return $_SERVER['REQUEST_URI'];
-		return '';
-	}
-
-	private function get_user_agent() {
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) )
-			return $_SERVER['HTTP_USER_AGENT'];
-		return false;
-	}
-
-	private function get_referrer() {
-		if ( isset( $_SERVER['HTTP_REFERER'] ) )
-			return $_SERVER['HTTP_REFERER'];
-		return false;
-	}
-
-	private function get_ip() {
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) )
-		  return $_SERVER['REMOTE_ADDR'];
-		elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) )
-		  return $_SERVER['HTTP_X_FORWARDED_FOR'];
-		return '';
 	}
 }

--- a/redirection.php
+++ b/redirection.php
@@ -30,6 +30,7 @@ include dirname( __FILE__ ).'/models/log.php';
 include dirname( __FILE__ ).'/models/flusher.php';
 include dirname( __FILE__ ).'/models/match.php';
 include dirname( __FILE__ ).'/models/action.php';
+include dirname( __FILE__ ).'/models/request.php';
 
 function red_get_options() {
 	$options = get_option( 'redirection_options' );

--- a/tests/models/test-request.php
+++ b/tests/models/test-request.php
@@ -1,0 +1,119 @@
+<?php
+
+class RequestTest extends WP_UnitTestCase {
+	private function monitorAction( $hook ) {
+		$action = new MockAction();
+
+		add_action( $hook, array( $action, 'action' ), 10, 2 );
+
+		return $action;
+	}
+
+	private function getActionData( $action ) {
+		$data = $action->get_args();
+
+		return $data[0][0];
+	}
+
+	public function testNoRequestUri() {
+		$action = $this->monitorAction( 'redirection_request_url' );
+		unset( $_SERVER['REQUEST_URI'] );
+
+		$result = Redirection_Request::get_request_url();
+
+		$this->assertEquals( '', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( '', $this->getActionData( $action ) );
+	}
+
+	public function testGoodRequestUri() {
+		$action = $this->monitorAction( 'redirection_request_url' );
+		$_SERVER['REQUEST_URI'] = 'test';
+
+		$result = Redirection_Request::get_request_url();
+
+		$this->assertEquals( 'test', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( 'test', $this->getActionData( $action ) );
+	}
+
+	public function testNoUserAgent() {
+		$action = $this->monitorAction( 'redirection_request_agent' );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+
+		$result = Redirection_Request::get_user_agent();
+
+		$this->assertEquals( '', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( '', $this->getActionData( $action ) );
+	}
+
+	public function testGoodUserAgent() {
+		$action = $this->monitorAction( 'redirection_request_agent' );
+		$_SERVER['HTTP_USER_AGENT'] = 'user agent';
+
+		$result = Redirection_Request::get_user_agent();
+
+		$this->assertEquals( 'user agent', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( 'user agent', $this->getActionData( $action ) );
+	}
+
+	public function testNoReferrer() {
+		$action = $this->monitorAction( 'redirection_request_referrer' );
+		unset( $_SERVER['HTTP_REFERER'] );
+
+		$result = Redirection_Request::get_referrer();
+
+		$this->assertEquals( '', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( '', $this->getActionData( $action ) );
+	}
+
+	public function testGoodReferrer() {
+		$action = $this->monitorAction( 'redirection_request_referrer' );
+		$_SERVER['HTTP_REFERER'] = 'referrer';
+
+		$result = Redirection_Request::get_referrer();
+
+		$this->assertEquals( 'referrer', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( 'referrer', $this->getActionData( $action ) );
+	}
+
+	public function testNoIP() {
+		$action = $this->monitorAction( 'redirection_request_ip' );
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		unset( $_SERVER['REMOTE_ADDR'] );
+
+		$result = Redirection_Request::get_ip();
+
+		$this->assertEquals( '', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( '', $this->getActionData( $action ) );
+	}
+
+	public function testPreferForwardedIP() {
+		$action = $this->monitorAction( 'redirection_request_ip' );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = 'forwarded';
+		$_SERVER['REMOTE_ADDR'] = 'remote address';
+
+		$result = Redirection_Request::get_ip();
+
+		$this->assertEquals( 'forwarded', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( 'forwarded', $this->getActionData( $action ) );
+	}
+
+	public function testDefaultHostIP() {
+		$action = $this->monitorAction( 'redirection_request_ip' );
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		$_SERVER['REMOTE_ADDR'] = 'remote address';
+
+		$result = Redirection_Request::get_ip();
+
+		$this->assertEquals( 'remote address', $result );
+		$this->assertEquals( 1, $action->get_call_count() );
+		$this->assertEquals( 'remote address', $this->getActionData( $action ) );
+	}
+}


### PR DESCRIPTION
Move all server request information to a central place, removing inconsistencies between the different parts of the plugin.

Also adds filters for custom usage.

Fixes #69
Fixes #73 
