### PR TITLE
Update CSV multiple line test

### DIFF
--- a/fileio/csv.php
+++ b/fileio/csv.php
@@ -11,10 +11,14 @@ class Red_Csv_File extends Red_FileIO {
 
 		$stdout = fopen( 'php://output', 'w' );
 
-		fputcsv( $stdout, array( 'source', 'target', 'regex', 'type', 'code', 'match', 'hits', 'title' ) );
+		$this->output_to_file( $stdout, $items );
+	}
+
+	public function output_to_file( $handle, array $items ) {
+		fputcsv( $handle, array( 'source', 'target', 'regex', 'type', 'code', 'match', 'hits', 'title' ) );
 
 		foreach ( $items as $line ) {
-			fwrite( $stdout, $this->item_as_csv( $line )."\n" );
+			fwrite( $handle, $this->item_as_csv( $line ).PHP_EOL );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: johnny5
 Donate link: http://urbangiraffe.com/about/
 Tags: post, admin, seo, pages, manage, 301, 404, redirect, permalink
 Requires at least: 4.2
-Tested up to: 4.7
-Stable tag: 2.5
+Tested up to: 4.7.5
+Stable tag: 2.6
 
 Redirection is a WordPress plugin to manage 301 redirections and keep track of 404 errors without requiring knowledge of Apache .htaccess files.
 

--- a/tests/fileio/test-export-csv.php
+++ b/tests/fileio/test-export-csv.php
@@ -39,4 +39,23 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$this->assertEquals( '"\'"', $exporter->escape_csv( "'" ) );
 		$this->assertEquals( '""""', $exporter->escape_csv( '"' ) );
 	}
+
+	public function testMultipleLines() {
+		$exporter = new Red_Csv_File();
+		$item1 = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source1', 'action_data' => '/target', 'action_code' => 301 ) );
+		$item2 = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source2', 'action_data' => '/target', 'action_code' => 301 ) );
+
+		$temp = fopen( 'php://memory', 'w+' );
+
+		$exporter->output_to_file( $temp, array( $item1, $item2 ) );
+		rewind($temp);
+		$result = stream_get_contents( $temp );
+
+		$lines = array_filter( explode( PHP_EOL, $result ) );
+
+		$this->assertEquals( 3, count( $lines ) );
+		$this->assertEquals( 'source,target,regex,type,code,match,hits,title', $lines[0] );
+		$this->assertEquals( '"/source1","/target","0","url","301","url","0",""', $lines[1] );
+		$this->assertEquals( '"/source2","/target","0","url","301","url","0",""', $lines[2] );
+	}
 }


### PR DESCRIPTION
A bug in the CSV export (3c3eda3a4e4c0c36d11984e2a268c30c69b2964b) caused multiple lines to appear without a newline. This adds a unit test to check for the situation