### PR TITLE
Add basic position ordering

### DIFF
--- a/client/component/redirects/edit.js
+++ b/client/component/redirects/edit.js
@@ -120,7 +120,7 @@ class EditRedirect extends React.Component {
 		this.handleData = this.onSetData.bind( this );
 		this.handleAdvanced = this.onAdvanced.bind( this );
 
-		const { url, regex, match_type, action_type, action_data, group_id = 0, title, action_code } = props.item;
+		const { url, regex, match_type, action_type, action_data, group_id = 0, title, action_code, position } = props.item;
 		const { logged_in = '', logged_out = '' } = action_data;
 
 		this.state = {
@@ -132,6 +132,7 @@ class EditRedirect extends React.Component {
 			action_code,
 			action_data,
 			group_id,
+			position,
 
 			login: {
 				logged_in,
@@ -182,7 +183,7 @@ class EditRedirect extends React.Component {
 	}
 
 	onSave( ev ) {
-		const { url, title, regex, match_type, action_type, group_id, action_code } = this.state;
+		const { url, title, regex, match_type, action_type, group_id, action_code, position } = this.state;
 		const groups = this.props.group.rows;
 
 		const redirect = {
@@ -192,6 +193,7 @@ class EditRedirect extends React.Component {
 			regex,
 			match_type,
 			action_type,
+			position,
 			group_id: group_id > 0 ? group_id : groups[ 0 ].id,
 			action_code: this.getCode() ? parseInt( action_code, 10 ) : 0,
 			action_data: getActionData( this.state ),
@@ -348,13 +350,17 @@ class EditRedirect extends React.Component {
 
 	getGroup() {
 		const groups = this.props.group.rows;
-		const { group_id } = this.state;
+		const { group_id, position } = this.state;
+		const { advanced } = this.state;
 
 		return (
 			<tr>
 				<th>{ __( 'Group' ) }</th>
 				<td>
 					<Select name="group" value={ group_id } items={ nestedGroups( groups ) } onChange={ this.handleGroup } />
+					&nbsp;
+					{ advanced && <strong>{ __( 'Position' ) }</strong> }
+					{ advanced && <input type="number" value={ position } name="position" min="0" size="3" onChange={ this.handleChange } /> }
 				</td>
 			</tr>
 		);

--- a/client/component/redirects/index.js
+++ b/client/component/redirects/index.js
@@ -37,6 +37,10 @@ const headers = [
 		title: __( 'URL' ),
 	},
 	{
+		name: 'position',
+		title: __( 'Pos' ),
+	},
+	{
 		name: 'last_count',
 		title: __( 'Hits' ),
 	},

--- a/client/component/redirects/row.js
+++ b/client/component/redirects/row.js
@@ -138,7 +138,7 @@ class RedirectRow extends React.Component {
 	}
 
 	render() {
-		const { id, url, hits, last_access, enabled, title } = this.props.item;
+		const { id, url, hits, last_access, enabled, title, position } = this.props.item;
 		const { selected, status } = this.props;
 		const isLoading = status === STATUS_IN_PROGRESS;
 		const isSaving = status === STATUS_SAVING;
@@ -156,6 +156,9 @@ class RedirectRow extends React.Component {
 
 				{ this.state.editing ? <td><EditRedirect item={ this.props.item } onCancel={ this.handleCancel } /></td> : this.renderSource( url, title, isSaving ) }
 
+				<td>
+					{ numberFormat( position ) }
+				</td>
 				<td>
 					{ numberFormat( hits ) }
 				</td>

--- a/client/index.scss
+++ b/client/index.scss
@@ -101,6 +101,11 @@
 		text-align: left;
 	}
 
+	.column-position {
+		width: 60px;
+		text-align: left;
+	}
+
 	.column-type {
 		width: 50px;
 		text-align: left;

--- a/client/index.scss
+++ b/client/index.scss
@@ -184,6 +184,12 @@ input.current-page {
 	input[type=text] {
 		width: 80%;
 	}
+
+	input[name=position] {
+		width: 60px;
+		margin-left: 10px;
+		padding-top: 4px;
+	}
 }
 
 .redirects {

--- a/client/state/redirect/initial.js
+++ b/client/state/redirect/initial.js
@@ -11,6 +11,6 @@ export function getInitialRedirect() {
 		saving: [],
 		total: 0,
 		status: STATUS_IN_PROGRESS,
-		table: getDefaultTable( [ 'name' ], [ 'group' ], 'name', [ '' ] )
+		table: getDefaultTable( [ 'url', 'position', 'last_count', 'id', 'last_access' ], [ 'group' ], 'id', [ '' ] )
 	};
 }

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -304,7 +304,7 @@ class Red_Item {
 		$offset = 0;
 		$where = '';
 
-		if ( isset( $params['orderBy'] ) && in_array( $params['orderBy'], array( 'url', 'last_count', 'last_access' ), true ) ) {
+		if ( isset( $params['orderBy'] ) && in_array( $params['orderBy'], array( 'url', 'last_count', 'last_access', 'position' ), true ) ) {
 			$orderby = $params['orderBy'];
 		}
 

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -102,8 +102,9 @@ class Red_Item {
 	}
 
 	static function sort_urls( $first, $second ) {
-		if ( $first['position'] === $second['position'] )
+		if ( $first['position'] === $second['position'] ) {
 			return 0;
+		}
 
 		return ($first['position'] < $second['position']) ? -1 : 1;
 	}
@@ -361,6 +362,7 @@ class Red_Item {
 			'hits' => $this->get_hits(),
 			'regex' => $this->is_regex(),
 			'group_id' => $this->get_group_id(),
+			'position' => $this->get_position(),
 			'last_access' => $this->get_last_hit() > 0 ? date_i18n( get_option( 'date_format' ), $this->get_last_hit() ) : '-',
 			'enabled' => $this->is_enabled(),
 		);
@@ -378,6 +380,7 @@ class Red_Item_Sanitize {
 		$data['title'] = isset( $details['title'] ) ? $details['title'] : null;
 		$data['url'] = $this->get_url( isset( $details['url'] ) ? $details['url'] : $this->auto_generate(), $data['regex'] );
 		$data['group_id'] = $this->get_group( isset( $details['group_id'] ) ? $details['group_id'] : 0 );
+		$data['position'] = $this->get_position( $details );
 
 		$matcher = Red_Match::create( isset( $details['match_type'] ) ? $details['match_type'] : false );
 		if ( ! $matcher ) {
@@ -406,6 +409,14 @@ class Red_Item_Sanitize {
 		}
 
 		return apply_filters( 'redirection_validate_redirect', $data );
+	}
+
+	protected function get_position( $details ) {
+		if ( isset( $details['position'] ) ) {
+			return max( 0, intval( $details['position'], 10 ) );
+		}
+
+		return 0;
 	}
 
 	protected function is_url_type( $type ) {

--- a/tests/models/test-redirect-sanitize.php
+++ b/tests/models/test-redirect-sanitize.php
@@ -120,4 +120,17 @@ class RedirectSanitizeTest extends WP_UnitTestCase {
 		$result = $this->sanitizer->get( $this->get_new( array( 'match_type' => 'login' ) ) );
 		$this->assertEquals( serialize( array( 'logged_in' => '', 'logged_out' => '' ) ), $result['action_data'] );
 	}
+
+	public function testBadPosition() {
+		$result = $this->sanitizer->get( $this->get_new( array( 'position' => 'cat' ) ) );
+		$this->assertEquals( 0, $result['position'] );
+
+		$result = $this->sanitizer->get( $this->get_new( array( 'position' => -1 ) ) );
+		$this->assertEquals( 0, $result['position'] );
+	}
+
+	public function testGoodPosition() {
+		$result = $this->sanitizer->get( $this->get_new( array( 'position' => 6 ) ) );
+		$this->assertEquals( 6, $result['position'] );
+	}
 }


### PR DESCRIPTION
Add basic support for editing the position value. The position is shown on the redirect list, and is available for editing when the advanced toggle is pressed.

Better support will be added in the future. Specifically drag-and-drop ordering. There are some other issues that make ordering more complicated which will require some thought so as not to break things