### PR TITLE
Delete 404/logs by search or IP filter

### DIFF
--- a/client/component/logs/delete-all.js
+++ b/client/component/logs/delete-all.js
@@ -5,8 +5,13 @@
 import React from 'react';
 import { translate as __ } from 'lib/locale';
 import Modal from 'component/modal';
+import PropTypes from 'prop-types';
 
 class DeleteAll extends React.Component {
+	static propTypes = {
+		table: PropTypes.object.isRequired,
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -26,14 +31,47 @@ class DeleteAll extends React.Component {
 	}
 
 	handleDelete() {
+		const { table } = this.props;
+
 		this.setState( { isModal: false } );
-		this.props.onDelete();
+		this.props.onDelete( this.getFilterBy( table.filterBy, table.filter ), table.filter );
+	}
+
+	getFilterBy( filterBy, filter ) {
+		if ( filter ) {
+			if ( filterBy ) {
+				return filterBy;
+			}
+
+			return 'url';
+		}
+
+		return '';
+	}
+
+	getTitle( filterBy, filter ) {
+		if ( filterBy === 'ip' ) {
+			return __( 'Delete all from IP %s', {
+				args: filter,
+			} );
+		}
+
+		if ( filter ) {
+			return __( 'Delete all matching "%s"', {
+				args: filter.substring( 0, 15 ),
+			} );
+		}
+
+		return __( 'Delete All' );
 	}
 
 	render() {
+		const { table } = this.props;
+		const title = this.getTitle( table.filterBy, table.filter );
+
 		return (
 			<div className="table-button-item">
-				<input className="button" type="submit" name="" value={ __( 'Delete All' ) } onClick={ this.onShow } />
+				<input className="button" type="submit" name="" value={ title } onClick={ this.onShow } />
 
 				<Modal show={ this.state.isModal } onClose={ this.onClose }>
 					<div>

--- a/client/component/logs/index.js
+++ b/client/component/logs/index.js
@@ -93,7 +93,7 @@ class Logs extends React.Component {
 					<TableButtons enabled={ rows.length > 0 }>
 						<ExportCSV logType={ LOGS_TYPE_REDIRECT } />
 						<button className="button-secondary" onClick={ this.handleRSS }>RSS</button>
-						<DeleteAll onDelete={ this.props.onDeleteAll } />
+						<DeleteAll onDelete={ this.props.onDeleteAll } table={ table } />
 					</TableButtons>
 				</TableNav>
 			</div>
@@ -114,8 +114,8 @@ function mapDispatchToProps( dispatch ) {
 		onLoad: logType => {
 			dispatch( loadLogs( logType ) );
 		},
-		onDeleteAll: () => {
-			dispatch( deleteAll() );
+		onDeleteAll: ( filterBy, filter ) => {
+			dispatch( deleteAll( filterBy, filter ) );
 		},
 		onSearch: search => {
 			dispatch( setSearch( search ) );

--- a/client/component/logs404/index.js
+++ b/client/component/logs404/index.js
@@ -88,8 +88,8 @@ class Logs404 extends React.Component {
 
 				<TableNav total={ total } selected={ table.selected } table={ table } status={ status } onChangePage={ this.props.onChangePage } onAction={ this.props.onTableAction }>
 					<TableButtons enabled={ rows.length > 0 }>
-						<DeleteAll onDelete={ this.props.onDeleteAll } />
 						<ExportCSV logType={ LOGS_TYPE_404 } />
+						<DeleteAll onDelete={ this.props.onDeleteAll } table={ table } />
 					</TableButtons>
 				</TableNav>
 			</div>
@@ -113,8 +113,8 @@ function mapDispatchToProps( dispatch ) {
 		onLoadGroups: () => {
 			dispatch( getGroup() );
 		},
-		onDeleteAll: () => {
-			dispatch( deleteAll() );
+		onDeleteAll: ( filterBy, filter ) => {
+			dispatch( deleteAll( filterBy, filter ) );
 		},
 		onSearch: search => {
 			dispatch( setSearch( search ) );

--- a/client/component/logs404/row.js
+++ b/client/component/logs404/row.js
@@ -9,7 +9,7 @@ import { translate as __ } from 'lib/locale';
 /**
  * Internal dependencies
  */
-import { setFilter, setSelected, performTableAction } from 'state/log/action';
+import { setFilter, setSelected, performTableAction, deleteExact } from 'state/log/action';
 import RowActions from 'component/table/row-action';
 import Referrer from './referrer';
 import EditRedirect from 'component/redirects/edit';
@@ -27,8 +27,13 @@ class LogRow404 extends React.Component {
 		this.handleAdd = this.onAdd.bind( this );
 		this.handleShow = this.onShow.bind( this );
 		this.handleClose = this.onClose.bind( this );
+		this.handleSave = this.onSave.bind( this );
+		this.handleDeleteLog = this.onDeleteLog.bind( this );
 
-		this.state = { editing: false };
+		this.state = {
+			editing: false,
+			delete_log: false,
+		};
 	}
 
 	onSelect() {
@@ -54,11 +59,32 @@ class LogRow404 extends React.Component {
 		this.setState( { editing: false } );
 	}
 
+	onDeleteLog( ev ) {
+		this.setState( { delete_log: ev.target.checked } );
+	}
+
+	onSave() {
+		if ( this.state.delete_log ) {
+			this.props.onDeleteFilter( this.props.item.url );
+		}
+	}
+
 	renderEdit() {
 		return (
 			<Modal show={ this.state.editing } onClose={ this.handleClose } width="700">
 				<div className="add-new">
-					<EditRedirect item={ getDefaultItem( this.props.item.url, 0 ) } saveButton={ __( 'Add Redirect' ) } advanced={ false } onCancel={ this.handleClose } />
+					<EditRedirect item={ getDefaultItem( this.props.item.url, 0 ) } saveButton={ __( 'Add Redirect' ) } advanced={ false } onCancel={ this.handleClose } childSave={ this.handleSave }>
+						<tr>
+							<th>{ __( 'Delete 404s' ) }</th>
+							<td>
+								<label>
+									<input type="checkbox" name="delete_log" checked={ this.state.delete_log } onChange={ this.handleDeleteLog } />
+
+									{ __( 'Delete all logs for this 404' ) }
+								</label>
+							</td>
+						</tr>
+					</EditRedirect>
 				</div>
 			</Modal>
 		);
@@ -116,6 +142,9 @@ function mapDispatchToProps( dispatch ) {
 		},
 		onDelete: item => {
 			dispatch( performTableAction( 'delete', item, { logType: '404' } ) );
+		},
+		onDeleteFilter: filter => {
+			dispatch( deleteExact( 'url-exact', filter ) );
 		},
 	};
 }

--- a/client/component/redirects/edit.js
+++ b/client/component/redirects/edit.js
@@ -238,6 +238,10 @@ class EditRedirect extends React.Component {
 		} else {
 			this.reset();
 		}
+
+		if ( this.props.childSave ) {
+			this.props.childSave();
+		}
 	}
 
 	onAdvanced( ev ) {
@@ -453,6 +457,8 @@ class EditRedirect extends React.Component {
 						{ this.getTarget() }
 						{ this.getGroup() }
 
+						{ this.props.children && this.props.children }
+
 						<tr>
 							<th></th>
 							<td>
@@ -476,6 +482,7 @@ EditRedirect.propTypes = {
 	item: PropTypes.object.isRequired,
 	onCancel: PropTypes.func,
 	saveButton: PropTypes.string,
+	childSave: PropTypes.func,
 	advanced: PropTypes.bool,
 };
 

--- a/client/component/redirects/edit.js
+++ b/client/component/redirects/edit.js
@@ -436,7 +436,7 @@ class EditRedirect extends React.Component {
 						<tr>
 							<th>{ __( 'Source URL' ) }</th>
 							<td>
-								<input type="text" name="url" value={ url } onChange={ this.handleChange } /> &nbsp;
+								<input type="text" name="url" value={ url } onChange={ this.handleChange } autoFocus={ ! this.props.advanced } /> &nbsp;
 								<label>
 									{ __( 'Regex' ) } <sup><a tabIndex="-1" target="_blank" rel="noopener noreferrer" href="https://urbangiraffe.com/plugins/redirection/regex/">?</a></sup>
 									&nbsp;

--- a/client/lib/store/index.js
+++ b/client/lib/store/index.js
@@ -80,9 +80,9 @@ const deepCompare = ( first, second ) => {
 	return true;
 };
 
-export const processRequest = ( action, dispatch, status, params = {}, state = {} ) => {
+export const processRequest = ( action, dispatch, status, params = {}, state = {}, reduxer = s => s ) => {
 	const { table, rows } = state;
-	const tableData = mergeWithTable( table, params );
+	const tableData = reduxer( mergeWithTable( table, params ) );
 	const data = removeDefaults( { ... table, ... params }, status.order );
 
 	if ( deepCompare( tableData, table ) && rows.length > 0 && deepCompare( params, {} ) ) {
@@ -98,6 +98,19 @@ export const processRequest = ( action, dispatch, status, params = {}, state = {
 		} );
 
 	return dispatch( { table: tableData, type: status.saving, ... objectDiff( tableData, params ) } );
+};
+
+export const directApi = ( action, dispatch, status, params, state ) => {
+	const { table } = state;
+	const data = removeDefaults( { ... table, ... params }, status.order );
+
+	getApi( action, data )
+		.then( json => {
+			dispatch( { type: status.saved, ... json } );
+		} )
+		.catch( error => {
+			dispatch( { type: status.failed, error } );
+		} );
 };
 
 const copyReplace = ( data, item, cb ) => {

--- a/client/state/log/action.js
+++ b/client/state/log/action.js
@@ -11,12 +11,15 @@ import {
 	LOG_SET_SELECTED,
 	LOG_SET_ALL_SELECTED,
 } from './type';
-import { tableAction, processRequest } from 'lib/store';
+import { tableAction, processRequest, directApi } from 'lib/store';
 
 const STATUS_LOG_ITEM = { saving: LOG_ITEM_SAVING, saved: LOG_ITEM_SAVED, failed: LOG_ITEM_FAILED, order: 'date' };
 const STATUS_LOG = { saving: LOG_LOADING, saved: LOG_LOADED, failed: LOG_FAILED, order: 'date' };
 
-export const deleteAll = () => ( dispatch, getState ) => processRequest( 'red_delete_all', dispatch, STATUS_LOG, { logType: getState().log.logType }, getState().log );
+export const deleteExact = ( filterBy, filter ) => ( dispatch, getState ) => directApi( 'red_delete_all', dispatch, STATUS_LOG, { page: 0, filter, filterBy, logType: getState().log.logType }, getState().log );
+export const deleteAll = ( filterBy, filter ) => ( dispatch, getState ) => processRequest( 'red_delete_all', dispatch, STATUS_LOG, { page: 0, filter, filterBy, logType: getState().log.logType }, getState().log, table =>{
+	return { ... table, filter: '', filterBy: '' };
+} );
 export const performTableAction = ( action, ids, extra ) => tableAction( 'log', 'red_log_action', action, ids, STATUS_LOG_ITEM, extra );
 export const getLogs = args => ( dispatch, getState ) => {
 	const { log } = getState();

--- a/models/log.php
+++ b/models/log.php
@@ -75,7 +75,7 @@ class RE_Log {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}redirection_logs WHERE group_id=%d", $id ) );
 	}
 
-	static function delete_all( $filterBy, $filter ) {
+	static function delete_all( $filterBy = '', $filter = '' ) {
 		global $wpdb;
 
 		$where = array();

--- a/models/log.php
+++ b/models/log.php
@@ -75,25 +75,23 @@ class RE_Log {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}redirection_logs WHERE group_id=%d", $id ) );
 	}
 
-	static function delete_all( $type = 'all', $id = 0 ) {
+	static function delete_all( $filterBy, $filter ) {
 		global $wpdb;
 
 		$where = array();
-		if ( $type === 'module' )
-			$where[] = $wpdb->prepare( 'module_id=%d', $id );
-		elseif ( $type === 'group' )
-			$where[] = $wpdb->prepare( 'group_id=%d AND redirection_id IS NOT NULL', $id );
-		elseif ( $type === 'redirect' )
-			$where[] = $wpdb->prepare( 'redirection_id=%d', $id );
 
-		// if ( isset( $_REQUEST['s'] ) )
-		// 	$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+		if ( $filterBy === 'url' && $filter ) {
+			$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $filter ).'%' );
+		} else if ( $filterBy === 'ip' ) {
+			$where[] = $wpdb->prepare( 'ip=%s', $filter );
+		}
 
 		$where_cond = '';
-		if ( count( $where ) > 0 )
+		if ( count( $where ) > 0 ) {
 			$where_cond = ' WHERE '.implode( ' AND ', $where );
+		}
 
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_logs ".$where_cond );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_logs".$where_cond );
 	}
 
 	static function export_to_csv() {
@@ -112,8 +110,6 @@ class RE_Log {
 
 		$extra = '';
 		$sql = "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_logs";
-		// if ( isset( $_REQUEST['s'] ) )
-		// 	$extra = $wpdb->prepare( ' WHERE url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
 
 		$total_items = $wpdb->get_var( $sql.$extra );
 		$exported = 0;
@@ -204,18 +200,25 @@ class RE_404 {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}redirection_404 WHERE id=%d", $id ) );
 	}
 
-	static function delete_all() {
+	static function delete_all( $filterBy = '', $filter = '' ) {
 		global $wpdb;
 
 		$where = array();
-		// if ( isset( $_REQUEST['s'] ) )
-		// 	$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $_REQUEST['s'] ).'%' );
+
+		if ( $filterBy === 'url-exact' ) {
+			$where[] = $wpdb->prepare( 'url=%s', $filter );
+		} if ( $filterBy === 'url' && $filter ) {
+			$where[] = $wpdb->prepare( 'url LIKE %s', '%'.$wpdb->esc_like( $filter ).'%' );
+		} else if ( $filterBy === 'ip' ) {
+			$where[] = $wpdb->prepare( 'ip=INET_ATON(%s)', $filter );
+		}
 
 		$where_cond = '';
-		if ( count( $where ) > 0 )
+		if ( count( $where ) > 0 ) {
 			$where_cond = ' WHERE '.implode( ' AND ', $where );
+		}
 
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_404 ".$where_cond );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_404".$where_cond );
 	}
 
 	static function export_to_csv() {

--- a/redirection-api.php
+++ b/redirection-api.php
@@ -347,12 +347,23 @@ class Redirection_Api {
 
 	public function ajax_delete_all( $params ) {
 		$params = $this->get_params( $params );
+		$filter = '';
+		$filterBy = '';
+		if ( isset( $params['filter'] ) ) {
+			$filter = $params['filter'];
+		}
+
+		if ( isset( $params['filterBy'] ) && in_array( $params['filterBy'], array( 'url', 'ip', 'url-exact' ), true ) ) {
+			$filterBy = $params['filterBy'];
+			unset( $params['filter'] );
+			unset( $params['filterBy'] );
+		}
 
 		if ( isset( $params['logType'] ) ) {
 			if ( $params['logType'] === 'log' ) {
-				RE_Log::delete_all();
+				RE_Log::delete_all( $filterBy, $filter );
 			} else {
-				RE_404::delete_all();
+				RE_404::delete_all( $filterBy, $filter );
 			}
 		}
 

--- a/tests/api/test-delete-all.php
+++ b/tests/api/test-delete-all.php
@@ -47,4 +47,20 @@ class RedirectionApiDeleteAllTest extends WP_Ajax_UnitTestCase {
 		$this->assertTrue( is_array( $result->items ) );
 		$this->assertEquals( 0, $result->total );
 	}
+
+	public function testDeleteFilter() {
+		$this->createAB( 4 );
+		$result = $this->do_action( array( 'logType' => 'log', 'filter' => 'test1', 'filterBy' => 'url' ) );
+
+		$this->assertTrue( is_array( $result->items ) );
+		$this->assertEquals( 3, $result->total );
+	}
+
+	public function testDeleteFilterIP() {
+		$this->createAB( 4 );
+		$result = $this->do_action( array( 'logType' => 'log', 'filter' => '192.168.1.2', 'filterBy' => 'ip' ) );
+
+		$this->assertTrue( is_array( $result->items ) );
+		$this->assertEquals( 3, $result->total );
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ const config = {
 		modules: [ path.resolve( __dirname, 'client' ), 'node_modules' ],
 	},
 	plugins: [
+		new webpack.BannerPlugin( 'Redirection v' + pkg.version ),
 		new webpack.DefinePlugin( {
 			'process.env': { NODE_ENV: JSON.stringify( process.env.NODE_ENV || 'development' ) },
 			REDIRECTION_VERSION: "'" + pkg.version + "'",


### PR DESCRIPTION
When searching or filtering the 404 or redirect logs then you can now delete exactly the items that match.

Also when adding a 404, add a checkbox to allow matching 404 logs to be deleted.