### PR TITLE
Update URL monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following special words can be inserted into a target URL:
 
 - `redirection_permalink_changed` - return boolean if a post's permalink has changed
 - `redirection_remove_existing` - fired when a post changes permalink and we need to clear existing redirects that might affect it
+- `redirection_monitor_created` - fired when a redirect is created for a monitor post type. Supplied with the new redirect, old post, and post ID
 
 Additionally, if the target URL is a number without any slashes then Redirection will treat it as a post ID and redirect to the full URL for that post.
 

--- a/client/lib/api/index.js
+++ b/client/lib/api/index.js
@@ -29,6 +29,10 @@ const getApi = ( action, params, file ) => {
 
 	return getApiRequest( action, params, file )
 		.then( data => {
+			if ( ! data || ! data.status ) {
+				throw { message: 'No data or status object returned in request', code: 0 };
+			}
+
 			if ( data.status && data.statusText ) {
 				request.status = data.status;
 				request.statusText = data.statusText;

--- a/client/state/settings/__tests__/reducer.js
+++ b/client/state/settings/__tests__/reducer.js
@@ -34,9 +34,9 @@ describe( 'groups reducer', () => {
 	} );
 
 	test( 'SETTING_LOAD_SUCCESS sets load progress, values, and groups', () => {
-		const state = reducer( DEFAULT_STATE, { type: SETTING_LOAD_SUCCESS, values: 1, groups: 2, installed: 'install', canDelete: false } );
+		const state = reducer( DEFAULT_STATE, { type: SETTING_LOAD_SUCCESS, values: 1, groups: 2, installed: 'install', postTypes: [], canDelete: false } );
 
-		expect( state ).toEqual( { ... DEFAULT_STATE, loadStatus: STATUS_COMPLETE, values: 1, groups: 2, installed: 'install', canDelete: false } );
+		expect( state ).toEqual( { ... DEFAULT_STATE, loadStatus: STATUS_COMPLETE, values: 1, groups: 2, postTypes: [], installed: 'install', canDelete: false } );
 	} );
 
 	test( 'SETTING_LOAD_FAILED sets failed', () => {

--- a/client/state/settings/action.js
+++ b/client/state/settings/action.js
@@ -21,7 +21,7 @@ export const loadSettings = () => ( dispatch, getState ) => {
 
 	getApi( 'red_load_settings' )
 		.then( json => {
-			dispatch( { type: SETTING_LOAD_SUCCESS, values: json.settings, groups: json.groups, installed: json.installed, canDelete: json.canDelete } );
+			dispatch( { type: SETTING_LOAD_SUCCESS, values: json.settings, groups: json.groups, postTypes: json.post_types, installed: json.installed, canDelete: json.canDelete } );
 		} )
 		.catch( error => {
 			dispatch( { type: SETTING_LOAD_FAILED, error } );

--- a/client/state/settings/initial.js
+++ b/client/state/settings/initial.js
@@ -11,6 +11,7 @@ export function getInitialSettings() {
 		error: false,
 		installed: '',
 		settings: {},
+		postTypes: [],
 		pluginStatus: [],
 		canDelete: false,
 	};

--- a/client/state/settings/reducer.js
+++ b/client/state/settings/reducer.js
@@ -22,7 +22,7 @@ export default function settings( state = {}, action ) {
 			return { ... state, loadStatus: STATUS_IN_PROGRESS };
 
 		case SETTING_LOAD_SUCCESS:
-			return { ... state, loadStatus: STATUS_COMPLETE, values: action.values, groups: action.groups, installed: action.installed, canDelete: action.canDelete };
+			return { ... state, loadStatus: STATUS_COMPLETE, values: action.values, groups: action.groups, postTypes: action.postTypes, installed: action.installed, canDelete: action.canDelete };
 
 		case SETTING_LOAD_FAILED:
 			return { ... state, loadStatus: STATUS_FAILED, error: action.error };

--- a/models/monitor.php
+++ b/models/monitor.php
@@ -42,10 +42,6 @@ class Red_Monitor {
 
 		// Hierarchical post? Do nothing
 		$type = get_post_type( $post->ID );
-		if ( is_post_type_hierarchical( $post->post_type ) && $type !== 'page' ) {
-			return false;
-		}
-
 		if ( ! in_array( $type, $this->monitor_types ) ) {
 			return false;
 		}

--- a/models/monitor.php
+++ b/models/monitor.php
@@ -124,13 +124,17 @@ class Red_Monitor {
 			);
 
 			// Create a new redirect for this post
-			Red_Item::create( $data );
+			$new_item = Red_Item::create( $data );
 
-			if ( !empty( $this->associated ) ) {
-				// Create an associated redirect for this post
-				$data['url'] = trailingslashit( $data['url'] ) . ltrim( $this->associated, '/' );
-				$data['action_data'] = array( 'url' => trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' ) );
-				Red_Item::create( $data );
+			if ( ! is_wp_error( $new_item ) ) {
+				do_action( 'redirection_monitor_created', $new_item, $before, $post_id );
+
+				if ( !empty( $this->associated ) ) {
+					// Create an associated redirect for this post
+					$data['url'] = trailingslashit( $data['url'] ) . ltrim( $this->associated, '/' );
+					$data['action_data'] = array( 'url' => trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' ) );
+					Red_Item::create( $data );
+				}
 			}
 
 			return true;

--- a/redirection-api.php
+++ b/redirection-api.php
@@ -278,6 +278,7 @@ class Redirection_Api {
 			'groups' => $this->groups_to_json( Red_Group::get_for_select() ),
 			'installed' => get_home_path(),
 			'canDelete' => ! is_multisite(),
+			'post_types' => red_get_post_types(),
 		) );
 	}
 

--- a/tests/api/test-settings.php
+++ b/tests/api/test-settings.php
@@ -59,7 +59,7 @@ class RedirectionApiSettingsTest extends WP_Ajax_UnitTestCase {
 		$data = "1";
 		$this->setNonce();
 
-		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => $data, 'monitor_type_post' => true ) ) );
+		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => $data, 'monitor_types' => array( 'post' ) ) ) );
 		$this->assertEquals( 1, $result->settings->monitor_post );
 		$this->assertEquals( array( 'post' ), $result->settings->monitor_types );
 	}
@@ -73,13 +73,13 @@ class RedirectionApiSettingsTest extends WP_Ajax_UnitTestCase {
 
 	public function testMonitorTypes() {
 		$this->setNonce();
-		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => '1', 'monitor_type_post' => true, 'monitor_type_page' => true, 'monitor_type_trash' => true ) ) );
+		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => '1', 'monitor_types' => array( 'post', 'page', 'trash' ) ) ) );
 		$this->assertEquals( array( 'post', 'page', 'trash' ), $result->settings->monitor_types );
 	}
 
 	public function testAssociatedRedirect() {
 		$this->setNonce();
-		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => '1', 'monitor_type_post' => true, 'associated_redirect' => '/amp/' ) ) );
+		$result = json_decode( self::$redirection->ajax_save_settings( array( 'monitor_post' => '1', 'monitor_types' => array( 'post' ), 'associated_redirect' => '/amp/' ) ) );
 		$this->assertEquals( '/amp/', $result->settings->associated_redirect );
 	}
 


### PR DESCRIPTION
Change how monitoring is done so it no longer relies on checking $_POST, but directly compares the before and after permalinks.

This makes it available to monitoring quick edits, as well as anywhere else such as via the REST API.

Additionally custom post types are no available for monitoring

Fixes #524
Fixes #540
