### PR TITLE
Add regex parsing to 'url and custom filter' match type's target urls

### DIFF
--- a/matches/custom-filter.php
+++ b/matches/custom-filter.php
@@ -38,7 +38,6 @@ class Custom_Match extends Red_Match {
 			if ( $regex ) {
 				$target = $this->get_target_regex_url( $matched_url, $this->url_from, $url );
 			}
-
 		} elseif ( ! $matched && $this->url_notfrom !== '' ) {
 			$target = $this->url_notfrom;
 			if ( $regex ) {

--- a/matches/custom-filter.php
+++ b/matches/custom-filter.php
@@ -35,8 +35,15 @@ class Custom_Match extends Red_Match {
 		// Check if referrer matches
 		if ( $matched && $this->url_from !== '' ) {
 			$target = $this->url_from;
+			if ( $regex ) {
+				$target = $this->get_target_regex_url( $matched_url, $this->url_from, $url );
+			}
+
 		} elseif ( ! $matched && $this->url_notfrom !== '' ) {
 			$target = $this->url_notfrom;
+			if ( $regex ) {
+				$target = $this->get_target_regex_url( $matched_url, $this->url_notfrom, $url );
+			}
 		}
 
 		return $target;


### PR DESCRIPTION
It seems that the 'URL and custom filter' match type does not properly parse captured regex groups in the target urls. This should fix it.

Originating wordpress.org thread: https://wordpress.org/support/topic/url-and-custom-filter-match-no-regex-captured/