### PR TITLE
wp_query->posts should be an array type

### DIFF
--- a/actions/error.php
+++ b/actions/error.php
@@ -23,7 +23,7 @@ class Error_Action extends Red_Action {
 		global $wp_query;
 
 		// Page comments plugin interferes with this
-		$wp_query->posts = false;
+		$wp_query->posts = array();
 		return false;
 	}
 


### PR DESCRIPTION
Fixes an issue when Timber is used alongside Redirection: https://github.com/timber/timber/issues/1698

This could also have been fixed within Timber, but from what I can tell wp_query->posts will never be set to false in the Wordpress core, so I think the fix belongs here. Also, since it is an array type, this seems more consistent.