### PR TITLE
ability to disable counter with a filter

### DIFF
--- a/models/redirect.php
+++ b/models/redirect.php
@@ -248,9 +248,11 @@ class Red_Item {
 
 		$options = red_get_options();
 
-		// Update the counters
-		$this->last_count++;
-		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}redirection_items SET last_count=last_count+1, last_access=NOW() WHERE id=%d", $this->id ) );
+        // Update the counters
+        $this->last_count++;
+        if ( isset( $options['count_redirect'] ) && $options['count_redirect'] && apply_filters( 'redirection_count_redirect_override', true ) ) {
+            $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}redirection_items SET last_count=last_count+1, last_access=NOW() WHERE id=%d", $this->id ) );
+        }
 
 		if ( isset( $options['expire_redirect'] ) && $options['expire_redirect'] !== -1 && $target ) {
 			RE_Log::create( $url, $target, Redirection_Request::get_user_agent(), Redirection_Request::get_ip(), Redirection_Request::get_referrer(), array( 'redirect_id' => $this->id, 'group_id' => $this->group_id ) );

--- a/redirection-settings.php
+++ b/redirection-settings.php
@@ -163,6 +163,7 @@ function red_get_options() {
 		'auto_target'         => '',
 		'expire_redirect'     => 7,   // Expire in 7 days
 		'expire_404'          => 7,   // Expire in 7 days
+        'count_redirect'      => true,
 		'modules'             => array(),
 		'newsletter'          => false,
 		'redirect_cache'      => 1,   // 1 hour


### PR DESCRIPTION
I needed to disable the redirect counter. Currently you can only disable the counter via a filter. However I made a default option for the functionality. If this feature needed I can add a select into the options tab. Maybe even hide the hits from the Redirects tab.