### PR TITLE
Add a WordPress page type matcher

### DIFF
--- a/client/component/redirects/action/url.js
+++ b/client/component/redirects/action/url.js
@@ -12,21 +12,22 @@ import PropTypes from 'prop-types';
 
 const ActionUrl = props => {
 	const changer = ev => {
-		props.onChange( 'target', 'url', ev.target.value );
+		props.onChange( props.target, 'url', ev.target.value );
 	};
 
 	return (
 		<tr>
 			<th>{ __( 'Target URL' ) }</th>
 			<td>
-				<input type="text" name="url" value={ props.target.url } onChange={ changer } placeholder={ __( 'The target URL you want to redirect to if matched' ) } />
+				<input type="text" name="url" value={ props.url } onChange={ changer } placeholder={ __( 'The target URL you want to redirect to if matched' ) } />
 			</td>
 		</tr>
 	);
 };
 
 ActionUrl.propTypes = {
-	target: PropTypes.object.isRequired,
+	url: PropTypes.string.isRequired,
+	target: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
 };
 

--- a/client/component/redirects/constants.js
+++ b/client/component/redirects/constants.js
@@ -20,6 +20,7 @@ import {
 	MATCH_ROLE,
 	MATCH_SERVER,
 	MATCH_IP,
+	MATCH_PAGE,
 } from 'state/redirect/selector';
 
 export const getMatches = () => [
@@ -62,6 +63,10 @@ export const getMatches = () => [
 	{
 		value: MATCH_CUSTOM,
 		name: __( 'URL and custom filter' ),
+	},
+	{
+		value: MATCH_PAGE,
+		name: __( 'URL and WordPress page type' ),
 	},
 ];
 

--- a/client/component/redirects/edit.js
+++ b/client/component/redirects/edit.js
@@ -20,6 +20,7 @@ import MatchCookie from './match/cookie';
 import MatchRole from './match/role';
 import MatchServer from './match/server';
 import MatchIp from './match/ip';
+import MatchPage from './match/page';
 import ActionLogin from './action/login';
 import ActionUrl from './action/url';
 import ActionUrlFrom from './action/url-from';
@@ -42,6 +43,7 @@ import {
 	MATCH_ROLE,
 	MATCH_SERVER,
 	MATCH_IP,
+	MATCH_PAGE,
 
 	getActionData,
 	hasUrlTarget,
@@ -86,6 +88,7 @@ class EditRedirect extends React.Component {
 			role: this.getRoleState( action_data ),
 			server: this.getServerState( action_data ),
 			ip: this.getIpState( action_data ),
+			page: this.getPageState( action_data ),
 		};
 
 		this.state.advanced = ! this.canShowAdvanced();
@@ -186,6 +189,10 @@ class EditRedirect extends React.Component {
 				url_from: '',
 				url_notfrom: '',
 			},
+			page: {
+				page: '404',
+				url: '',
+			},
 		};
 	}
 
@@ -244,6 +251,15 @@ class EditRedirect extends React.Component {
 			ip,
 			url_from,
 			url_notfrom,
+		};
+	}
+
+	getPageState( action_data ) {
+		const { page = '404', url = '' } = action_data ? action_data : {};
+
+		return {
+			page,
+			url,
 		};
 	}
 
@@ -381,7 +397,7 @@ class EditRedirect extends React.Component {
 	}
 
 	getMatchExtra() {
-		const { match_type, agent, referrer, cookie, header, custom, role, server, ip } = this.state;
+		const { match_type, agent, referrer, cookie, header, custom, role, server, ip, page } = this.state;
 
 		switch ( match_type ) {
 			case MATCH_AGENT:
@@ -407,13 +423,16 @@ class EditRedirect extends React.Component {
 
 			case MATCH_IP:
 				return <MatchIp ip={ ip.ip } onChange={ this.onSetData } />;
+
+			case MATCH_PAGE:
+				return <MatchPage page={ page.page } onChange={ this.onSetData } />;
 		}
 
 		return null;
 	}
 
 	getTarget() {
-		const { match_type, action_type, agent, referrer, login, cookie, target, header, custom, role, server, ip } = this.state;
+		const { match_type, action_type, agent, referrer, login, cookie, target, header, custom, role, server, ip, page } = this.state;
 
 		if ( ! hasUrlTarget( action_type ) ) {
 			return null;
@@ -430,7 +449,7 @@ class EditRedirect extends React.Component {
 				return <ActionLogin logged_in={ login.logged_in } logged_out={ login.logged_out } onChange={ this.onSetData } />;
 
 			case MATCH_URL:
-				return <ActionUrl target={ target } onChange={ this.onSetData } />;
+				return <ActionUrl url={ target.url } target="target" onChange={ this.onSetData } />;
 
 			case MATCH_COOKIE:
 				return <ActionUrlFrom url_from={ cookie.url_from } url_notfrom={ cookie.url_notfrom } target="cookie" onChange={ this.onSetData } />;
@@ -449,6 +468,9 @@ class EditRedirect extends React.Component {
 
 			case MATCH_IP:
 				return <ActionUrlFrom url_from={ ip.url_from } url_notfrom={ ip.url_notfrom } target="ip" onChange={ this.onSetData } />;
+
+			case MATCH_PAGE:
+				return <ActionUrl url={ page.url } target="page" onChange={ this.onSetData } />;
 		}
 
 		return null;
@@ -532,7 +554,7 @@ class EditRedirect extends React.Component {
 	}
 
 	canSave() {
-		const { url, match_type, target, action_type, referrer, login, agent, header, cookie, role, server } = this.state;
+		const { url, match_type, target, action_type, referrer, login, agent, header, cookie, role, server, ip, page } = this.state;
 
 		if ( Redirectioni10n.autoGenerate === '' && url === '' ) {
 			return false;
@@ -568,6 +590,14 @@ class EditRedirect extends React.Component {
 			}
 
 			if ( match_type === MATCH_SERVER && server.url_from === '' && server.url_notfrom === '' ) {
+				return false;
+			}
+
+			if ( match_type === MATCH_IP && ip.url_from === '' && ip.url_notfrom === '' ) {
+				return false;
+			}
+
+			if ( match_type === MATCH_PAGE && page.url === '' ) {
 				return false;
 			}
 		}

--- a/client/component/redirects/match/page.js
+++ b/client/component/redirects/match/page.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate as __ } from 'lib/locale';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+
+class MatchPage extends React.Component {
+	static propTypes = {
+		page: PropTypes.string.isRequired,
+	};
+
+	onChange = ev => {
+		this.props.onChange( 'page', 'page', ev.target.value );
+	}
+
+	render() {
+		return (
+			<tr>
+				<th>{ __( 'Page Type' ) }</th>
+				<td>
+					{ __( 'Only the 404 page type is currently supported.' ) }&nbsp;
+					{ __( 'Please do not try and redirect all your 404s - this is not a good thing to do.' ) }
+				</td>
+			</tr>
+		);
+	}
+}
+
+export default MatchPage;

--- a/client/state/redirect/selector.js
+++ b/client/state/redirect/selector.js
@@ -14,6 +14,7 @@ export const MATCH_CUSTOM = 'custom';
 export const MATCH_ROLE = 'role';
 export const MATCH_SERVER = 'server';
 export const MATCH_IP = 'ip';
+export const MATCH_PAGE = 'page';
 
 export const CODE_PASS = 'pass';
 export const CODE_NOTHING = 'nothing';
@@ -21,7 +22,7 @@ export const CODE_NOTHING = 'nothing';
 export const hasUrlTarget = type => type === ACTION_URL || type === ACTION_PASS;
 
 export const getActionData = state => {
-	const { agent, referrer, login, match_type, target, action_type, header, cookie, custom, role, server, ip } = state;
+	const { agent, referrer, login, match_type, target, action_type, header, cookie, custom, role, server, ip, page } = state;
 
 	if ( match_type === MATCH_COOKIE ) {
 		return {
@@ -103,6 +104,13 @@ export const getActionData = state => {
 	if ( match_type === MATCH_URL && hasUrlTarget( action_type ) ) {
 		return {
 			url: target.url,
+		};
+	}
+
+	if ( match_type === MATCH_PAGE && hasUrlTarget( action_type ) ) {
+		return {
+			page: page.page,
+			url: hasUrlTarget( action_type ) ? page.url : '',
 		};
 	}
 

--- a/matches/page.php
+++ b/matches/page.php
@@ -10,7 +10,7 @@ class Page_Match extends Red_Match {
 	}
 
 	public function save( array $details, $no_target_url = false ) {
-		$data = array( 'page' => isset( $details['page'] ) ? $this->sanitize_page( $details['page'] ) : [] );
+		$data = array( 'page' => isset( $details['page'] ) ? $this->sanitize_page( $details['page'] ) : '404' );
 
 		return $this->save_data( $details, $no_target_url, $data );
 	}

--- a/matches/page.php
+++ b/matches/page.php
@@ -1,0 +1,46 @@
+<?php
+
+class Page_Match extends Red_Match {
+	use FromUrl_Match;
+
+	public $page;
+
+	public function name() {
+		return __( 'URL and WordPress page type', 'redirection' );
+	}
+
+	public function save( array $details, $no_target_url = false ) {
+		$data = array( 'page' => isset( $details['page'] ) ? $this->sanitize_page( $details['page'] ) : [] );
+
+		return $this->save_data( $details, $no_target_url, $data );
+	}
+
+	private function sanitize_page( $page ) {
+		return '404';
+	}
+
+	public function get_target( $url, $matched_url, $regex ) {
+		if ( ! is_404() ) {
+			return false;
+		}
+
+		$target = $this->get_matched_target( true );
+
+		if ( $regex && $target ) {
+			return $this->get_target_regex_url( $matched_url, $target, $url );
+		}
+
+		return $target;
+	}
+
+	public function get_data() {
+		return array_merge( array(
+			'page' => $this->page,
+		), $this->get_from_data() );
+	}
+
+	public function load( $values ) {
+		$values = $this->load_data( $values );
+		$this->page = $values['page'];
+	}
+}

--- a/models/match.php
+++ b/models/match.php
@@ -1,10 +1,16 @@
 <?php
 
 abstract class Red_Match {
+	protected $type;
+
 	public function __construct( $values = '' ) {
 		if ( $values ) {
 			$this->load( $values );
 		}
+	}
+
+	public function get_type() {
+		return $this->type;
 	}
 
 	abstract public function save( array $details, $no_target_url = false );
@@ -36,7 +42,9 @@ abstract class Red_Match {
 				include( dirname( __FILE__ ) . '/../matches/' . $avail[ strtolower( $name ) ] );
 			}
 
-			return new $classname( $data );
+			$class = new $classname( $data );
+			$class->type = $name;
+			return $class;
 		}
 
 		return false;
@@ -66,6 +74,45 @@ abstract class Red_Match {
 			'role'     => 'user-role.php',
 			'server'   => 'server.php',
 			'ip'       => 'ip.php',
+			'page'     => 'page.php',
+		);
+	}
+}
+
+trait FromUrl_Match {
+	public $url;
+
+	private function save_data( array $details, $no_target_url, array $data ) {
+		if ( $no_target_url === false ) {
+			return array_merge( array(
+				'url' => isset( $details['url'] ) ? $this->sanitize_url( $details['url'] ) : '',
+			), $data );
+		}
+
+		return $data;
+	}
+
+	private function get_matched_target( $matched ) {
+		if ( $matched ) {
+			return $this->url;
+		}
+
+		return false;
+	}
+
+	private function load_data( $values ) {
+		$values = unserialize( $values );
+
+		if ( isset( $values['url'] ) ) {
+			$this->url = $values['url'];
+		}
+
+		return $values;
+	}
+
+	private function get_from_data() {
+		return array(
+			'url' => $this->url,
 		);
 	}
 }

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -42,15 +42,42 @@ class WordPress_Module extends Red_Module {
 	}
 
 	public function template_redirect() {
-		if ( is_404() ) {
-			$options = red_get_options();
+		if ( ! is_404() ) {
+			return;
+		}
 
-			if ( isset( $options['expire_404'] ) && $options['expire_404'] >= 0 && apply_filters( 'redirection_log_404', $this->can_log ) ) {
-				RE_404::create( Redirection_Request::get_request_url(), Redirection_Request::get_user_agent(), Redirection_Request::get_ip(), Redirection_Request::get_referrer() );
-			}
+		if ( $this->match_404_type( $this->redirects ) ) {
+			// Don't log an intentionally redirected 404
+			return;
+		}
+
+		$options = red_get_options();
+
+		if ( isset( $options['expire_404'] ) && $options['expire_404'] >= 0 && apply_filters( 'redirection_log_404', $this->can_log ) ) {
+			RE_404::create( Redirection_Request::get_request_url(), Redirection_Request::get_user_agent(), Redirection_Request::get_ip(), Redirection_Request::get_referrer() );
 		}
 	}
 
+	private function match_404_type( array $redirects ) {
+		if ( property_exists( $this, 'redirects' ) && count( $this->redirects ) > 0 ) {
+			return false;
+		}
+
+		$page_type = array_values( array_filter( $redirects, function( $redirect ) {
+			return $redirect->match->get_type() === 'page';
+		} ) );
+
+		if ( count( $page_type ) > 0 ) {
+			$url = apply_filters( 'redirection_url_source', Redirection_Request::get_request_url() );
+			$first = $page_type[0];
+			$first->matches( $url );
+			return true;
+		}
+
+		return false;
+	}
+
+	// Return true to stop further processing of the 'do nothing'
 	public function redirection_do_nothing() {
 		$this->can_log = false;
 		return true;
@@ -87,6 +114,11 @@ class WordPress_Module extends Red_Module {
 			}
 
 			do_action( 'redirection_last', $url, $this );
+
+			if ( ! $this->matched ) {
+				// Keep them for later
+				$this->redirects = $redirects;
+			}
 		}
 	}
 

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -42,11 +42,11 @@ class WordPress_Module extends Red_Module {
 	}
 
 	public function template_redirect() {
-		if ( ! is_404() ) {
+		if ( ! is_404() || $this->matched ) {
 			return;
 		}
 
-		if ( $this->match_404_type( $this->redirects ) ) {
+		if ( $this->match_404_type() ) {
 			// Don't log an intentionally redirected 404
 			return;
 		}
@@ -58,12 +58,12 @@ class WordPress_Module extends Red_Module {
 		}
 	}
 
-	private function match_404_type( array $redirects ) {
-		if ( property_exists( $this, 'redirects' ) && count( $this->redirects ) > 0 ) {
+	private function match_404_type() {
+		if ( ! property_exists( $this, 'redirects' ) || count( $this->redirects ) === 0 ) {
 			return false;
 		}
 
-		$page_type = array_values( array_filter( $redirects, function( $redirect ) {
+		$page_type = array_values( array_filter( $this->redirects, function( $redirect ) {
 			return $redirect->match->get_type() === 'page';
 		} ) );
 

--- a/tests/action/test-nothing.php
+++ b/tests/action/test-nothing.php
@@ -9,8 +9,7 @@ class NothingTest extends WP_UnitTestCase {
 	public function testNothingAction() {
 		$action = Red_Action::create( 'nothing', 1 );
 
-		$this->assertFalse( $action->process_before( 1, 'test' ) );
-
+		$this->assertTrue( $action->process_before( 1, 'test' ) );
 	}
 
 	public function test404Logs() {

--- a/tests/api/test-export.php
+++ b/tests/api/test-export.php
@@ -62,7 +62,7 @@ class ImportExportCsvTest extends Redirection_Api_Test {
 "/1","*","0","url","301","url","0",""';
 
 		$group1 = Red_Group::create( 'group1', 1 );
-		Red_Item::create( array( 'url' => '1', 'match_type' => 'url', 'action_type' => 'url', 'group_id' => $group1->get_id() ) );
+		Red_Item::create( array( 'url' => '/1', 'match_type' => 'url', 'action_type' => 'url', 'group_id' => $group1->get_id() ) );
 
 		$this->setNonce();
 		$result = $this->callApi( 'export/1/csv' );

--- a/tests/fileio/test-json.php
+++ b/tests/fileio/test-json.php
@@ -37,18 +37,18 @@ class JsonTest extends WP_UnitTestCase {
 					'name' => 'groupx',
 					'id' => 5,
 					'module_id' => 1,
-				)
+				),
 			),
 			'redirects' => array(
 				array(
-					'url' => 'source1',
+					'url' => '/source1',
 					'id' => 1,
 					'group_id' => 5,
 					'match_type' => 'url',
 					'action_type' => 'url',
 					'action_data' => array( 'url' => '/test' ),
-				)
-			)
+				),
+			),
 		);
 
 		$json = new Red_Json_File();

--- a/tests/fileio/test-rss.php
+++ b/tests/fileio/test-rss.php
@@ -3,7 +3,7 @@
 class ImportExportRss extends WP_UnitTestCase {
 	public function testExport() {
 		$group1 = Red_Group::create( 'group1', 1 );
-		$item = Red_Item::create( array( 'url' => '1', 'match_type' => 'url', 'action_type' => 'url', 'group_id' => $group1->get_id() ) );
+		$item = Red_Item::create( array( 'url' => '/1', 'match_type' => 'url', 'action_type' => 'url', 'group_id' => $group1->get_id() ) );
 
 		$exporter = Red_FileIO::create( 'rss' );
 		$xml = $exporter->get_data( array( $item ), array() );

--- a/tests/matches/test-page-match.php
+++ b/tests/matches/test-page-match.php
@@ -1,0 +1,68 @@
+<?php
+
+require dirname( __FILE__ ) . '/../../matches/page.php';
+
+class PageMatchTest extends WP_UnitTestCase {
+	private function set_404( $is_404 ) {
+		global $wp_query;
+
+		wp_reset_query();
+		set_query_var( 'is_404', $is_404 );
+
+		$wp_query->is_404 = $is_404;
+	}
+
+	public function testNoData() {
+		$match = new Page_Match();
+		$saved = array(
+			'url' => '',
+			'page' => '404',
+		);
+		$this->assertEquals( $saved, $match->save( array( 'bad' => 'thing' ) ) );
+	}
+
+	public function testBadPage() {
+		$match = new Page_Match();
+		$saved = array(
+			'url' => '',
+			'page' => '404',
+		);
+		$this->assertEquals( $saved, $match->save( array( 'page' => '505' ) ) );
+	}
+
+	public function testGoodPage() {
+		$match = new Page_Match();
+		$saved = array(
+			'url' => '',
+			'page' => '404',
+		);
+		$this->assertEquals( $saved, $match->save( array( 'page' => '404' ) ) );
+	}
+
+	public function testLoadBad() {
+		$match = new Page_Match();
+		$match->load( serialize( array( 'url' => 'O:8:"stdClass":1:{s:5:"hello";s:5:"world";}', 'page' => '' ) ) );
+		$this->assertEquals( 'O:8:"stdClass":1:{s:5:"hello";s:5:"world";}', $match->url );
+	}
+
+	public function test404Url() {
+		$this->set_404( true );
+
+		$match = new Page_Match( serialize( array( 'page' => '404', 'url' => '/target' ) ) );
+		$this->assertEquals( '/target', $match->get_target( '/cat', '/cat', false ) );
+	}
+
+	public function test404UrlRegex() {
+		$this->set_404( true );
+
+		$match = new Page_Match( serialize( array( 'page' => '404', 'url' => '/from$1' ) ) );
+		$this->assertEquals( '/from1', $match->get_target( '/from1', '/from(.*)', true ) );
+	}
+
+	public function testNot404Url() {
+		$this->set_404( false );
+
+		$match = new Page_Match( serialize( array( 'page' => '404', 'url' => '/cat' ) ) );
+		$this->assertEquals( false, $match->get_target( '/cat', '/cat', false ) );
+	}
+}

--- a/tests/models/test-redirect-sanitize.php
+++ b/tests/models/test-redirect-sanitize.php
@@ -64,7 +64,7 @@ class RedirectSanitizeTest extends WP_UnitTestCase {
 
 	public function testEmptyUrl() {
 		$result = $this->sanitizer->get( $this->get_new( array( 'url' => '' ) ) );
-		$this->assertEquals( '/', $result['url'] );
+		$this->assertWPError( $result );
 	}
 
 	public function testUrl() {

--- a/tests/models/test-redirect.php
+++ b/tests/models/test-redirect.php
@@ -57,8 +57,8 @@ class RedirectTest extends WP_UnitTestCase {
 		$disabledGroup = Red_Group::create( 'group', 1 );
 		$disabledGroup->disable();
 
-		$item1 = $this->createRedirect( array( 'url' => 'url1' ) );
-		$item2 = $this->createRedirect( array( 'url' => 'url2' ) );
+		$item1 = $this->createRedirect( array( 'url' => '/url1' ) );
+		$item2 = $this->createRedirect( array( 'url' => '/url2' ) );
 		$item3 = $this->createRedirect( array( 'url' => 'url3', 'group_id' => $disabledGroup->get_id() ) );
 
 		$items = Red_Item::get_all_for_module( 1 );


### PR DESCRIPTION
This matches a URL and a WordPress page type. Currently only supports 404, allowing you to perform an action on 404 errors.

Fixes #686