### PR TITLE
Update 404 log behaviour

### DIFF
--- a/actions/error.php
+++ b/actions/error.php
@@ -17,6 +17,7 @@ class Error_Action extends Red_Action {
 	public function wp() {
 		status_header( $this->code );
 		nocache_headers();
+		header( 'X-Redirect-Agent: redirection' );
 	}
 
 	public function pre_handle_404() {

--- a/actions/error.php
+++ b/actions/error.php
@@ -11,7 +11,7 @@ class Error_Action extends Red_Action {
 		add_filter( 'pre_handle_404', array( $this, 'pre_handle_404' ) );
 		add_action( 'wp', array( $this, 'wp' ) );
 
-		return false;
+		return true;
 	}
 
 	public function wp() {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://redirection.me/donation/
 Tags: redirect, htaccess, 301, 404, seo, permalink, apache, nginx, post, admin
 Requires at least: 4.5
 Tested up to: 4.9.8
-Stable tag: 3.5
+Stable tag: 3.6
 Requires PHP: 5.4
 License: GPLv3
 
@@ -141,6 +141,7 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 * Add option to block 404s by IP
 * Add grouping of 404s by IP and URL
 * Add bulk block or redirect a group of 404s
+* Add option to redirect on a 404
 * Better page navigation change monitoring
 * Add URL & IP match
 * Add 303 and 304 redirect codes

--- a/tests/action/test-error.php
+++ b/tests/action/test-error.php
@@ -1,0 +1,33 @@
+<?php
+
+class ErrorTest extends WP_UnitTestCase {
+	private function set_404( $is_404 ) {
+		global $wp_query;
+
+		wp_reset_query();
+		set_query_var( 'is_404', $is_404 );
+
+		$wp_query->is_404 = $is_404;
+	}
+
+	public function setUp() {
+		$module = Redirection::init()->get_module();
+		$module->reset();
+	}
+
+	public function testErrorAction() {
+		global $wp_query;
+
+		$wp_query->posts = array( 1 );
+		$this->set_404( false );
+
+		$action = Red_Action::create( 'error', 1 );
+		$result = $action->process_before( 410, 'test' );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( get_query_var( 'is_404' ) );
+		$this->assertEquals( get_404_template(), $action->template_include() );
+		$this->assertFalse( $action->pre_handle_404() );
+		$this->assertEquals( [], $wp_query->posts );
+	}
+}


### PR DESCRIPTION
Error redirects will now appear in the normal log, not the 404 log. They will also trigger hits

Fixes #1024