### PR TITLE
Fixes passthrough to work with PHP Tools

### DIFF
--- a/actions/pass.php
+++ b/actions/pass.php
@@ -34,6 +34,7 @@ class Pass_Action extends Red_Action {
 	public function process_internal( $target ) {
 		// Another URL on the server
 		$_SERVER['REQUEST_URI'] = $target;
+		$_SERVER['PATH_INFO'] = $target;
 
 		if ( strpos( $target, '?' ) ) {
 			$_SERVER['QUERY_STRING'] = substr( $target, strpos( $target, '?' ) + 1 );


### PR DESCRIPTION
While using this plugin on the server running Apache worked perfectly we noticed the passthrough redirect wasn't working on our PHP Tools built in webserver.

This fixes it to work while hosting it locally using PHP Tools for Visual Studio's Built-in Web Server configuration.

Note that I am not a PHP developer in the slightest and so have no idea what consequences this will have beyond fixing the problem we were having.