### PR TITLE
Update row.js to show strike-through when titled rule has been disabled.

### DIFF
--- a/client/page/redirects/row.js
+++ b/client/page/redirects/row.js
@@ -145,7 +145,10 @@ class RedirectRow extends React.Component {
 		const { regex, match_type } = this.props.item;
 
 		if ( title ) {
-			return title;
+			if ( this.props.item.enabled ) {
+				return title;
+			}
+			return <strike>{ title }</strike>;
 		}
 
 		const fullUrl = this.getUrl( url, match_type );


### PR DESCRIPTION
Currently in the list of redirects:
When a Title (comment) is added to the rule, the Title shows _instead_ of the source Url that is to be matched.

But when the rule is disabled, there is no visual feedback that the rule has been disabled, because currently only the source url field has strike-through style applied (when the rule is disabled), and in the case of a title being present, this source url field is not shown.

This PR:  
adds strike-through text to the Title when a titled rule has been disabled, mimicking the visual feedback available for rules that do not supply a Title.

This is the version 1 solution mentioned for issue #1358

issue #1358 