### PR TITLE
log shows matched rule; query adds redirection_url

### DIFF
--- a/client/page/logs/index.js
+++ b/client/page/logs/index.js
@@ -34,7 +34,7 @@ const getHeaders = () => [
 	},
 	{
 		name: 'url',
-		title: __( 'Source URL' ),
+		title: __( 'Source URL / Sent To / Matched Rule' ),
 		primary: true,
 	},
 	{

--- a/client/page/logs/row.js
+++ b/client/page/logs/row.js
@@ -138,7 +138,8 @@ class LogRow extends React.Component {
 				</td>
 				<td className="column-primary column-url">
 					<ExternalLink url={ url }>{ url.substring( 0, 100 ) }</ExternalLink><br />
-					{ sent_to ? sent_to.substring( 0, 100 ) : '' }
+					{ sent_to ? sent_to.substring( 0, 100 ) : '' }<br />
+					{ redirection_url }
 
 					<RowActions disabled={ isSaving }>
 						{ menu.reduce( ( prev, curr ) => [ prev, ' | ', curr ] ) }

--- a/client/page/logs/row.js
+++ b/client/page/logs/row.js
@@ -110,7 +110,7 @@ class LogRow extends React.Component {
 	}
 
 	render() {
-		const { created, created_time, ip, referrer, url, agent, sent_to, id } = this.props.item;
+		const { created, created_time, ip, referrer, url, agent, sent_to, redirection_url, id } = this.props.item;
 		const { selected, status } = this.props;
 		const isLoading = status === STATUS_IN_PROGRESS;
 		const isSaving = status === STATUS_SAVING;

--- a/models/log.php
+++ b/models/log.php
@@ -21,7 +21,12 @@ class RE_Log {
 	static function get_by_id( $id ) {
 		global $wpdb;
 
-		$row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}redirection_logs WHERE id=%d", $id ) );
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT {$wpdb->prefix}redirection_logs.*,
+		                                               {$wpdb->prefix}redirection_items.url AS redirection_url
+												FROM {$wpdb->prefix}redirection_logs
+												INNER JOIN {$wpdb->prefix}redirection_items
+												ON {$wpdb->prefix}redirection_logs.redirection_id={$wpdb->prefix}redirection_items.id
+											    WHERE id=%d", $id ) );
 		if ( $row ) {
 			return new RE_Log( $row );
 		}


### PR DESCRIPTION
Partially addresses issue #722

- db query adds `redirection_url` as an alias column name
	to hold the url rule that was matched (when the redirect was logged).
	/models/log.php
	
-  `redirection_url` used to display the matched url rule 
	to the screen on the "logs" tab.
        /client/page/logs/row.js
	
- header for the column where `redirection_url` is displayed, was
        modified to indicate order of the (now) 3 urls shown in this column.
        /client/page/logs/index.js

	TODO:
	- would be nice to add an action item to edit the matched rule
	- maybe only display the matched rule if it's a regex, as "exact" url
	  would be identical to the source url?  

issue #722
