### PR TITLE
Update query param handling

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -1,0 +1,19 @@
+echo "Waiting for MySQL"
+cd /var/www/html
+sleep 20
+
+if ! $(wp core is-installed); then
+	echo "Setting up Redirection e2e tests"
+
+	wp core install --url=http://redirection-e2e.local --title="Redirection e2e tests" --admin_user=admin --admin_email=root@redirection-e2e.local --admin_password=password
+	wp rewrite structure '/%postname%'
+
+	# Setup plugin
+	wp plugin activate redirection
+	wp redirection database install
+	wp redirection import /opt/redirection/redirects.json
+
+	echo "CLI: Setup finished"
+else
+	echo "CLI: Already installed, exiting"
+fi

--- a/client/component/welcome-wizard/index.js
+++ b/client/component/welcome-wizard/index.js
@@ -32,9 +32,9 @@ const ApiResultIcon = ( { result, method } ) => {
 	return <span className="dashicons dashicons-no"></span>;
 };
 
-const ApiResult = ( { item, result, method } ) => {
+const ApiResult = ( { item, result, method, alt } ) => {
 	return (
-		<div className="api-result">
+		<div className={ 'api-result' + ( alt ? ' api-result-alt' : '' ) }>
 			<ApiResultIcon result={ result } method={ method } /> <code>{ method }</code> { item.text }
 
 			{ result[ method ] && result[ method ] !== true &&
@@ -295,12 +295,14 @@ class WelcomeWizard extends React.Component {
 				<button className="button wizard-retry" onClick={ this.onRetry } disabled={ this.apiInProgress() }>{ __( 'Retry' ) }</button>
 
 				<h3>{ __( 'Checking your REST API' ) }</h3>
-				{ routes.map( item =>
+				{ routes.map( ( item, pos ) =>
 					<React.Fragment key={ item.value } >
-						<ApiResult item={ item } result={ apiTest[ item.value ] } method="GET" />
-						<ApiResult item={ item } result={ apiTest[ item.value ] } method="POST" />
+						<ApiResult item={ item } result={ apiTest[ item.value ] } method="GET" alt={ pos % 2 === 1 } />
+						<ApiResult item={ item } result={ apiTest[ item.value ] } method="POST" alt={ pos % 2 === 1 } />
 					</React.Fragment>
 				) }
+
+				<p>{ __( 'You need at least one GET/POST pair for the plugin to work.' ) }</p>
 
 				<div className="wizard-buttons">
 					<button className="button-primary button" onClick={ this.finishSetup }>{ __( 'Finish Setup' ) }</button> &nbsp;

--- a/client/component/welcome-wizard/style.scss
+++ b/client/component/welcome-wizard/style.scss
@@ -127,3 +127,7 @@
 		font-weight: bold;
 	}
 }
+
+.api-result-alt {
+	background-color: #eee;
+}

--- a/client/page/options/options-form.js
+++ b/client/page/options/options-form.js
@@ -267,7 +267,7 @@ class OptionsForm extends React.Component {
 						<label>
 							<p>
 								<input type="checkbox" name="https" onChange={ this.onChange } checked={ this.state.https } />
-								{ __( 'Force a redirect from HTTP to HTTPS. Please ensure your HTTPS is working before enabling' ) }
+								{ __( 'Force a redirect from HTTP to the HTTPS version of your  WordPress site domain. Please ensure your HTTPS is working before enabling.' ) }
 								&nbsp; { __( '(beta)' ) }
 							</p>
 						</label>

--- a/database/database.php
+++ b/database/database.php
@@ -76,7 +76,7 @@ class Red_Database {
 	}
 
 	public static function apply_to_sites( $callback ) {
-		if ( is_network_admin() || defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( is_multisite() && ( is_network_admin() || defined( 'WP_CLI' ) && WP_CLI ) ) {
 			array_map( function( $site ) use ( $callback ) {
 				switch_to_blog( $site->blog_id );
 

--- a/database/database.php
+++ b/database/database.php
@@ -149,6 +149,11 @@ class Red_Database {
 				'file' => '400.php',
 				'class' => 'Red_Database_400',
 			],
+			[
+				'version' => '4.1',
+				'file' => '410.php',
+				'class' => 'Red_Database_410',
+			],
 		];
 	}
 }

--- a/database/schema/400.php
+++ b/database/schema/400.php
@@ -56,8 +56,11 @@ class Red_Database_400 extends Red_Database_Upgrader {
 		// All regex get match_url=regex
 		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url='regex' WHERE regex=1" );
 
-		// Lowercase, trim trailing, and remove query params
-		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=TRIM(TRAILING '/' FROM SUBSTRING_INDEX(LOWER(url), '?', 1)) WHERE regex=0" );
+		// Remove query part from all URLs and lowercase
+		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=SUBSTRING_INDEX(LOWER(url), '?', 1) WHERE regex=0" );
+
+		// Trim the last / from a URL
+		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=LEFT(match_url,LENGTH(match_url)-1) WHERE regex=0 AND match_url != '/' AND RIGHT(match_url, 1) = '/'" );
 
 		// Any URL that is now empty becomes /
 		return $this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url='/' WHERE match_url=''" );

--- a/database/schema/410.php
+++ b/database/schema/410.php
@@ -1,0 +1,17 @@
+<?php
+
+class Red_Database_410 extends Red_Database_Upgrader {
+	public function get_stages() {
+		return [
+			'handle_double_slash' => 'Support double-slash URLs',
+		];
+	}
+
+	protected function handle_double_slash( $wpdb ) {
+		// Update any URL with a double slash at the end
+		$this->do_query( $wpdb, "UPDATE {$wpdb->prefix}redirection_items SET match_url=LOWER(LEFT(SUBSTRING_INDEX(url, '?', 1),LENGTH(SUBSTRING_INDEX(url, '?', 1)) - 1)) WHERE RIGHT(SUBSTRING_INDEX(url, '?', 1), 2) = '//' AND regex=0" );
+
+		// Any URL that is now empty becomes /
+		return $this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url='/' WHERE match_url=''" );
+	}
+}

--- a/database/schema/latest.php
+++ b/database/schema/latest.php
@@ -53,6 +53,7 @@ class Red_Latest_Database extends Red_Database_Upgrader {
 		delete_option( 'redirection_index' );
 		delete_option( 'redirection_options' );
 		delete_option( Red_Database_Status::OLD_DB_VERSION );
+		delete_option( Red_Database_Status::DB_UPGRADE_STAGE );
 	}
 
 	/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.3'
+
+services:
+    db:
+        image: mysql:5.7
+        volumes:
+            - db_data:/var/lib/mysql
+        restart: always
+        ports:
+            - "3306:3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: somewordpress
+            MYSQL_DATABASE: wordpress
+            MYSQL_USER: wordpress
+            MYSQL_PASSWORD: wordpress
+
+    wordpress:
+        image: wordpress:latest
+        depends_on:
+            - db
+        ports:
+            - "80:80"
+        restart: always
+        environment:
+            WORDPRESS_DB_HOST: db:3306
+            WORDPRESS_DB_USER: wordpress
+            WORDPRESS_DB_PASSWORD: wordpress
+            WORDPRESS_DB_NAME: wordpress
+            VIRTUAL_HOST: redirectione2e.local
+        volumes:
+            - wordpress:/var/www/html
+            - ./:/var/www/html/wp-content/plugins/redirection
+
+    cli:
+        image: wordpress:cli
+        user: "33:33"
+        volumes:
+            - wordpress:/var/www/html
+            - ./:/var/www/html/wp-content/plugins/redirection
+            - ./bin/docker-setup.sh:/opt/redirection/docker-setup.sh
+            - ./e2e/redirects.json:/opt/redirection/redirects.json
+        links:
+            - db
+        depends_on:
+            - db
+            - wordpress
+        command: sh /opt/redirection/docker-setup.sh
+
+volumes:
+    db_data:
+    wordpress:

--- a/e2e/__tests__/url.json
+++ b/e2e/__tests__/url.json
@@ -256,5 +256,57 @@
 				"agent": true
 			}
 		}
+	],
+	[
+		"Test double-slash URL",
+		{
+			"source": {
+				"url": "//?query"
+			},
+			"target": {
+				"location": "/plain-redirect",
+				"status": 301,
+				"agent": true
+			}
+		}
+	],
+	[
+		"Test double-slash with other details",
+		{
+			"source": {
+				"url": "//thing/here"
+			},
+			"target": {
+				"location": "/plain-redirect",
+				"status": 301,
+				"agent": true
+			}
+		}
+	],
+	[
+		"Test query param array",
+		{
+			"source": {
+				"url": "/plain-array/?arr[]=1&arr[]=2&arr[]=3"
+			},
+			"target": {
+				"location": "/plain-redirect",
+				"status": 301,
+				"agent": true
+			}
+		}
+	],
+	[
+		"Test query param array merge",
+		{
+			"source": {
+				"url": "/plain-array-pass/?arr2[]=3&arr2[]=2&arr[]=3&arr[]=2&arr[]=1"
+			},
+			"target": {
+				"location": "/plain-redirect?arr2[]=3&arr2[]=2&arr[]=3&arr[]=2&arr[]=1",
+				"status": 301,
+				"agent": true
+			}
+		}
 	]
 ]

--- a/fileio/apache.php
+++ b/fileio/apache.php
@@ -108,7 +108,12 @@ class Red_Apache_File extends Red_FileIO {
 
 	private function decode_url( $url ) {
 		$url = rawurldecode( $url );
-		$url = str_replace( '\\.', '.', $url );
+
+		// Replace quoted slashes
+		$url = preg_replace( '@\\\/@', '/', $url );
+
+		// Ensure escaped '.' is still escaped
+		$url = preg_replace( '@\\\\.@', '\\\\.', $url );
 		return $url;
 	}
 
@@ -143,15 +148,17 @@ class Red_Apache_File extends Red_FileIO {
 	}
 
 	private function regex_url( $url ) {
+		$url = $this->decode_url( $url );
+
 		if ( $this->is_str_regex( $url ) ) {
 			$tmp = ltrim( $url, '^' );
 			$tmp = rtrim( $tmp, '$' );
 
-			if ( $this->is_str_regex( $tmp ) === false ) {
-				return '/' . $this->decode_url( $tmp );
+			if ( $this->is_str_regex( $tmp ) ) {
+				return '^/' . ltrim( $tmp, '/' );
 			}
 
-			return '/' . $this->decode_url( $url );
+			return '/' . ltrim( $tmp, '/' );
 		}
 
 		return $this->decode_url( $url );

--- a/fileio/json.php
+++ b/fileio/json.php
@@ -22,7 +22,7 @@ class Red_Json_File extends Red_FileIO {
 			}, $items ),
 		);
 
-		return wp_json_encode( $items, JSON_PRETTY_PRINT ) . PHP_EOL;
+		return wp_json_encode( $items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . PHP_EOL;
 	}
 
 	public function load( $group, $filename, $data ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,8 @@ const SVN_SOURCE_FILES = [
 	'!package-lock.json',
 	'!e2e/**',
 	'!e2e',
+	'!docker-compose.yml',
+	'!.DS_Store',
 ];
 
 function downloadLocale( locale, wpName, type ) {

--- a/models/url-match.php
+++ b/models/url-match.php
@@ -1,6 +1,8 @@
 <?php
 
 class Red_Url_Match {
+	private $url;
+
 	public function __construct( $url ) {
 		$this->url = $url;
 	}
@@ -15,13 +17,11 @@ class Red_Url_Match {
 	 */
 	public function get_url() {
 		// Remove query params
-		$path = wp_parse_url( $this->url, PHP_URL_PATH );
+		$url = new Red_Url_Path( $this->url );
+		$path = $url->get_without_trailing_slash();
 
 		// Lowercase everything
 		$path = strtolower( $path );
-
-		// Trim trailing slash
-		$path = rtrim( $path, '/' );
 
 		return $path ? $path : '/';
 	}

--- a/models/url-path.php
+++ b/models/url-path.php
@@ -1,32 +1,76 @@
 <?php
 
 class Red_Url_Path {
-	public function __construct( $url ) {
-		$this->path = $this->get_url_path( $url );
-	}
+	private $path;
 
-	private function get_url_path( $url ) {
-		$path = wp_parse_url( $url, PHP_URL_PATH );
-
-		return $path ? $path : '/';
+	public function __construct( $path ) {
+		$this->path = $this->get_path_component( $path );
 	}
 
 	public function is_match( $url, Red_Source_Flags $flags ) {
-		$source = $this->path;
-		$target = $this->get_url_path( $url );
+		$target = new Red_Url_Path( $url );
 
-		if ( $flags->is_ignore_case() ) {
-			// Case insensitive match
-			$source = strtolower( $source );
-			$target = strtolower( $target );
-		}
+		$target_path = $target->get();
+		$source_path = $this->get();
 
 		if ( $flags->is_ignore_trailing() ) {
 			// Ignore trailing slashes
-			$source = rtrim( $source, '/' );
-			$target = rtrim( $target, '/' );
+			$source_path = $this->get_without_trailing_slash();
+			$target_path = $target->get_without_trailing_slash();
 		}
 
-		return $target === $source;
+		if ( $flags->is_ignore_case() ) {
+			// Case insensitive match
+			$source_path = strtolower( $source_path );
+			$target_path = strtolower( $target_path );
+		}
+
+		return $target_path === $source_path;
+	}
+
+	public function get() {
+		return $this->path;
+	}
+
+	public function get_without_trailing_slash() {
+		// Return / or // as-is
+		if ( $this->path === '//' || $this->path === '/' ) {
+			return $this->path;
+		}
+
+		// Anything else remove the last /
+		return preg_replace( '@/$@', '', $this->get() );
+	}
+
+	// parse_url doesn't handle 'incorrect' URLs, such as those with double slashes
+	// These are often used in redirects, so we fall back to our own parsing
+	private function get_path_component( $url ) {
+		$path = $url;
+
+		if ( preg_match( '@^https?://@', $url, $matches ) > 0 ) {
+			$parts = explode( '://', $url );
+
+			if ( count( $parts ) > 1 ) {
+				$rest = explode( '/', $parts[1] );
+				$path = '/' . implode( '/', array_slice( $rest, 1 ) );
+			}
+		}
+
+		return $this->get_query_before( $path );
+	}
+
+	private function get_query_before( $url ) {
+		$qpos = strpos( $url, '?' );
+		$qrpos = strpos( $url, '\\?' );
+
+		if ( $qrpos !== false && $qrpos < $qpos ) {
+			return substr( $url, 0, $qrpos + strlen( $qrpos ) - 1 );
+		}
+
+		if ( $qpos === false ) {
+			return $url;
+		}
+
+		return substr( $url, 0, $qpos );
 	}
 }

--- a/models/url-query.php
+++ b/models/url-query.php
@@ -1,6 +1,8 @@
 <?php
 
 class Red_Url_Query {
+	const RECURSION_LIMIT = 10;
+
 	private $query = [];
 
 	public function __construct( $url ) {
@@ -20,6 +22,7 @@ class Red_Url_Query {
 
 		// Get list of whatever is left over
 		$query_diff = $this->get_query_diff( $this->query, $target );
+		$query_diff = array_merge( $query_diff, $this->get_query_diff( $target, $this->query ) );
 
 		if ( $flags->is_query_ignore() || $flags->is_query_pass() ) {
 			return true;  // This ignores all other query params
@@ -44,37 +47,104 @@ class Red_Url_Query {
 
 			// Now add any remaining params
 			$query_diff = $source_query->get_query_diff( $source_query->query, $request_query->query );
+			$query_diff = array_merge( $query_diff, $request_query->get_query_diff( $request_query->query, $source_query->query ) );
 
 			// Remove any params from $source that are present in $request - we dont allow
 			// predefined params to be overridden
 			foreach ( $query_diff as $key => $value ) {
-				$query_diff[ $key ] = urlencode( $value );
-
 				if ( isset( $source_query->query[ $key ] ) ) {
 					unset( $query_diff[ $key ] );
 				}
 			}
 
-			return add_query_arg( $query_diff, $target_url );
+			$query = http_build_query( $query_diff );
+			$query = preg_replace( '@%5B\d*%5D@', '[]', $query );
+
+			if ( $query ) {
+				return $target_url . ( strpos( $target_url, '?' ) === false ? '?' : '&' ) . $query;
+			}
 		}
 
 		return $target_url;
 	}
 
+	public function get() {
+		return $this->query;
+	}
+
 	private function get_url_query( $url ) {
 		$params = [];
+		$query = $this->get_query_after( $url );
 
-		$query = wp_parse_url( $url, PHP_URL_QUERY );
 		wp_parse_str( $query ? $query : '', $params );
 
 		return $params;
 	}
 
-	private function get_query_same( array $source_query, array $target_query ) {
-		return array_intersect_assoc( $source_query, $target_query );
+	public function get_query_after( $url ) {
+		$qpos = strpos( $url, '?' );
+		$qrpos = strpos( $url, '\\?' );
+
+		if ( $qpos === false ) {
+			return '';
+		}
+
+		if ( $qrpos !== false && $qrpos < $qpos ) {
+			return substr( $url, $qrpos + strlen( $qrpos ) );
+		}
+
+		return substr( $url, $qpos + 1 );
 	}
 
-	private function get_query_diff( array $source_query, array $target_query ) {
-		return array_diff_assoc( $target_query, $source_query );
+	public function get_query_same( array $source_query, array $target_query, $depth = 0 ) {
+		if ( $depth > self::RECURSION_LIMIT ) {
+			return [];
+		}
+
+		$same = [];
+		foreach ( $source_query as $key => $value ) {
+			if ( isset( $target_query[ $key ] ) ) {
+				$add = false;
+
+				if ( is_array( $value ) && is_array( $target_query[ $key ] ) ) {
+					$add = $this->get_query_same( $source_query[ $key ], $target_query[ $key ], $depth + 1 );
+
+					if ( count( $add ) !== count( $source_query[ $key ] ) ) {
+						$add = false;
+					}
+				} elseif ( is_string( $value ) && is_string( $target_query[ $key ] ) ) {
+					$add = $value === $target_query[ $key ] ? $value : false;
+				}
+
+				if ( ! empty( $add ) || $add === '' ) {
+					$same[ $key ] = $add;
+				}
+			}
+		}
+
+		return $same;
+	}
+
+	public function get_query_diff( array $source_query, array $target_query, $depth = 0 ) {
+		if ( $depth > self::RECURSION_LIMIT ) {
+			return [];
+		}
+
+		$diff = [];
+		foreach ( $source_query as $key => $value ) {
+			$found = false;
+
+			if ( isset( $target_query[ $key ] ) && is_array( $value ) && is_array( $target_query[ $key ] ) ) {
+				$add = $this->get_query_diff( $source_query[ $key ], $target_query[ $key ], $depth + 1 );
+
+				if ( ! empty( $add ) ) {
+					$diff[ $key ] = $add;
+				}
+			} elseif ( ! isset( $target_query[ $key ] ) || ! is_string( $value ) || ! is_string( $target_query[ $key ] ) || $target_query[ $key ] !== $source_query[ $key ] ) {
+				$diff[ $key ] = $value;
+			}
+		}
+
+		return $diff;
 	}
 }

--- a/models/url-query.php
+++ b/models/url-query.php
@@ -58,7 +58,7 @@ class Red_Url_Query {
 			}
 
 			$query = http_build_query( $query_diff );
-			$query = preg_replace( '@%5B\d*%5D@', '[]', $query );
+			$query = preg_replace( '@%5B\d*%5D@', '[]', $query );  // Make these look like []
 
 			if ( $query ) {
 				return $target_url . ( strpos( $target_url, '?' ) === false ? '?' : '&' ) . $query;

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -92,7 +92,7 @@ class WordPress_Module extends Red_Module {
 		$options = red_get_options();
 
 		if ( $options['https'] && ! is_ssl() ) {
-			$target = rtrim( Redirection_Request::get_server_name(), '/' ) . esc_url_raw( Redirection_Request::get_request_url() );
+			$target = rtrim( parse_url( home_url(), PHP_URL_HOST ), '/' ) . esc_url_raw( Redirection_Request::get_request_url() );
 			wp_safe_redirect( 'https://' . $target, 301 );
 			die();
 		}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lint": "eslint --cache --ext=.js src",
     "stat": "NODE_ENV=production webpack --json --mode production | webpack-bundle-size-analyzer",
     "e2e": "NODE_ENV=e2e jest e2e",
+    "up": "docker-compose up",
+    "down": "docker-compose down",
+    "clean": "docker-compose down && docker-compose rm && docker volume prune",
     "release": "rm -rf node_modules && yarn install && yarn dist && gulp version"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redirection",
-  "version": "4.0.1",
+  "version": "4.1",
   "description": "Redirection is a WordPress plugin to manage 301 redirections and keep track of 404 errors without requiring knowledge of Apache .htaccess files.",
   "main": "redirection.php",
   "sideEffects": true,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://redirection.me/donation/
 Tags: redirect, htaccess, 301, 404, seo, permalink, apache, nginx, post, admin
 Requires at least: 4.5
 Tested up to: 5.1
-Stable tag: 4.0
+Stable tag: 4.0.1
 Requires PHP: 5.4
 License: GPLv3
 
@@ -159,11 +159,13 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 
 == Changelog ==
 
-= 4.0.1 - ??? =
+= 4.0.1 - 2nd Mar 2019 =
 * Improve styling of query flags
 * Match DB upgrade for new match_url to creation script
+* Fix upgrade on some hosts where plugin is auto-updated
 * Fix pagination button style in WP 5.1
 * Fix IP match when action is 'error'
+* Fix database upgrade on multisite WP CLI
 
 = 4.0 - 23rd Feb 2019 =
 * Add option for case insensitive redirects

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://redirection.me/donation/
 Tags: redirect, htaccess, 301, 404, seo, permalink, apache, nginx, post, admin
 Requires at least: 4.5
 Tested up to: 5.1
-Stable tag: 4.0.1
+Stable tag: 4.1
 Requires PHP: 5.4
 License: GPLv3
 
@@ -158,6 +158,14 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 * Alters database to support case insensitivity, trailing slashes, and query params. Please backup your data
 
 == Changelog ==
+
+= 4.1 - ??? =
+* Fix 'force https' causing WP to redirect to admin URL when accessing www subdomain
+* Fix .htaccess import adding ^ to the source
+* Fix handling of double-slashed URLs
+* Fix WP CLI on single site
+* Add DB upgrade to catch URLs with double-slash URLs
+* Remove unnecssary escaped slashes from JSON output
 
 = 4.0.1 - 2nd Mar 2019 =
 * Improve styling of query flags

--- a/redirection-cli.php
+++ b/redirection-cli.php
@@ -67,9 +67,12 @@ class Redirection_Cli extends WP_CLI_Command {
 			}
 		} else {
 			$data = @file_get_contents( $args[0] );
+
 			if ( $data ) {
 				$count = $importer->load( $group, $args[0], $data );
-				WP_CLI::success( 'Imported ' . $count . ' as ' . $format );
+				WP_CLI::success( 'Imported ' . $count . ' redirects as ' . $format );
+			} else {
+				WP_CLI::error( 'Invalid import file' );
 			}
 		}
 	}

--- a/redirection-version.php
+++ b/redirection-version.php
@@ -1,5 +1,5 @@
 <?php
 
-define( 'REDIRECTION_VERSION', '4.0.1' );
+define( 'REDIRECTION_VERSION', '4.1' );
 define( 'REDIRECTION_BUILD', '894a7909eeb2e5b85bc90a6470e9c6bc' );
 define( 'REDIRECTION_MIN_WP', '4.5' );

--- a/redirection.php
+++ b/redirection.php
@@ -3,7 +3,7 @@
 Plugin Name: Redirection
 Plugin URI: https://redirection.me/
 Description: Manage all your 301 redirects and monitor 404 errors
-Version: 4.0.1
+Version: 4.1
 Author: John Godley
 Author URI: https://johngodley.com
 Text Domain: redirection
@@ -21,7 +21,7 @@ For full license details see license.txt
 ============================================================================================================
 */
 
-define( 'REDIRECTION_DB_VERSION', '4.0' );     // DB schema version. Only change if DB needs changing
+define( 'REDIRECTION_DB_VERSION', '4.1' );     // DB schema version. Only change if DB needs changing
 define( 'REDIRECTION_FILE', __FILE__ );
 define( 'REDIRECTION_DEV_MODE', false );
 

--- a/tests/database/sql/4.0.sql
+++ b/tests/database/sql/4.0.sql
@@ -1,0 +1,69 @@
+CREATE TABLE `{$prefix}redirection_items` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`url` mediumtext COLLATE utf8mb4_unicode_520_ci NOT NULL,
+	`match_url` varchar(2000) COLLATE utf8mb4_unicode_520_ci DEFAULT NULL,
+	`match_data` text COLLATE utf8mb4_unicode_520_ci,
+	`regex` int(11) unsigned NOT NULL DEFAULT '0',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	`last_count` int(10) unsigned NOT NULL DEFAULT '0',
+	`last_access` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+	`group_id` int(11) NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT 'enabled',
+	`action_type` varchar(20) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+	`action_code` int(11) unsigned NOT NULL,
+	`action_data` mediumtext COLLATE utf8mb4_unicode_520_ci,
+	`match_type` varchar(20) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+	`title` text COLLATE utf8mb4_unicode_520_ci,
+	PRIMARY KEY (`id`),
+	KEY `url` (`url`(191)),
+	KEY `status` (`status`),
+	KEY `regex` (`regex`),
+	KEY `group_idpos` (`group_id`,`position`),
+	KEY `group` (`group_id`),
+	KEY `match_url` (`match_url`(191))
+);
+
+CREATE TABLE `{$prefix}redirection_groups` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`name` varchar(50) NOT NULL,
+	`tracking` int(11) NOT NULL DEFAULT '1',
+	`module_id` int(11) unsigned NOT NULL DEFAULT '0',
+	`status` enum('enabled','disabled') NOT NULL DEFAULT 'enabled',
+	`position` int(11) unsigned NOT NULL DEFAULT '0',
+	PRIMARY KEY (`id`),
+	KEY `module_id` (`module_id`),
+	KEY `status` (`status`)
+);
+
+CREATE TABLE `{$prefix}redirection_logs` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`created` datetime NOT NULL,
+	`url` mediumtext NOT NULL,
+	`sent_to` mediumtext COLLATE utf8mb4_unicode_520_ci,
+	`agent` mediumtext NOT NULL,
+	`referrer` mediumtext COLLATE utf8mb4_unicode_520_ci,
+	`redirection_id` int(11) unsigned DEFAULT NULL,
+	`ip` varchar(45) DEFAULT NULL,
+	`module_id` int(11) unsigned NOT NULL,
+	`group_id` int(11) unsigned DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `created` (`created`),
+	KEY `redirection_id` (`redirection_id`),
+	KEY `ip` (`ip`),
+	KEY `group_id` (`group_id`),
+	KEY `module_id` (`module_id`)
+);
+
+CREATE TABLE `{$prefix}redirection_404` (
+	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`created` datetime NOT NULL,
+	`url` varchar(255) NOT NULL DEFAULT '',
+	`agent` varchar(255) DEFAULT NULL,
+	`referrer` varchar(255) DEFAULT NULL,
+	`ip` varchar(45) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `created` (`created`),
+	KEY `url` (`url`(191)),
+	KEY `referrer` (`referrer`(191)),
+	KEY `ip` (`ip`)
+);

--- a/tests/database/test-database-latest.php
+++ b/tests/database/test-database-latest.php
@@ -62,6 +62,7 @@ class LatestDatabaseTest extends WP_UnitTestCase {
 		add_option( 'redirection_root', 'test' );
 		add_option( 'redirection_index', 'test' );
 		add_option( Red_Database_Status::OLD_DB_VERSION, 'test' );
+		add_option( Red_Database_Status::DB_UPGRADE_STAGE, 'something' );
 
 		$database = new Red_Latest_Database();
 		$database->install();
@@ -76,6 +77,7 @@ class LatestDatabaseTest extends WP_UnitTestCase {
 		$this->assertFalse( get_option( 'redirection_root' ) );
 		$this->assertFalse( get_option( 'redirection_index' ) );
 		$this->assertFalse( get_option( Red_Database_Status::OLD_DB_VERSION ) );
+		$this->assertFalse( get_option( Red_Database_Status::DB_UPGRADE_STAGE ) );
 	}
 
 	public function testDefaultGroupsClean() {

--- a/tests/database/test-database-upgrade.php
+++ b/tests/database/test-database-upgrade.php
@@ -98,6 +98,8 @@ class DatabaseTester {
 			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '//' ] );
 			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/thing///' ] );
 			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/index.php' ] );
+		} elseif ( $ver === '4.0' ) {
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '//?s=no-results' ] );
 		}
 	}
 
@@ -124,6 +126,10 @@ class DatabaseTester {
 			$unit->assertEquals( '/', $rows[3]->match_url );
 			$unit->assertEquals( '/thing//', $rows[4]->match_url );
 			$unit->assertEquals( '/index.php', $rows[5]->match_url );
+		} elseif ( $ver === '4.0' ) {
+			$rows = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_items" );
+
+			$unit->assertEquals( '/', $rows[0]->match_url );
 		}
 	}
 }
@@ -288,7 +294,7 @@ class UpgradeDatabaseTest extends WP_UnitTestCase {
 	public function testGetUpgradesForSameVersion() {
 		$database = new Red_Database();
 		$upgrades = $database->get_upgrades_for_version( '2.2', false );
-		$this->assertEquals( 5, count( $upgrades ) );
+		$this->assertEquals( 6, count( $upgrades ) );
 	}
 
 	public function testGetUpgradesForUnknownVersion() {
@@ -305,11 +311,12 @@ class UpgradeDatabaseTest extends WP_UnitTestCase {
 		$tester = new DatabaseTester();
 
 		$versions = array(
-			'3.9',    // => 4.0
-			'2.3.4',  // => 2.4
-			'2.3.2',  // => 2.3.3
-			'2.3.1.1',  // => 2.3.2
-			'2.3.0',  // => 2.3.1
+			'4.0', // => 4.1
+			'3.9', // => 4.0
+			'2.3.4', // => 2.4
+			'2.3.2', // => 2.3.3
+			'2.3.1.1', // => 2.3.2
+			'2.3.0', // => 2.3.1
 			'2.1.19', // => 2.2
 			'2.1.15', // => 2.1.16
 			'2.0.0',  // => 2.0.1
@@ -345,7 +352,7 @@ class UpgradeDatabaseTest extends WP_UnitTestCase {
 				}
 
 				if ( $info['result'] === 'error' ) {
-					$this->fail( $ver . ' ' . $info['reason'] );
+					$this->fail( $info['current'] . ' ' . $info['reason'] );
 				}
 
 				if ( $last === $status->get_current_stage() ) {
@@ -397,7 +404,7 @@ class UpgradeDatabaseTest extends WP_UnitTestCase {
 			}
 
 			if ( $info['result'] === 'error' ) {
-				$this->fail( $ver . ' ' . $info['reason'] );
+				$this->fail( $info['current'] . ' ' . $info['reason'] );
 			}
 		}
 

--- a/tests/database/test-database-upgrade.php
+++ b/tests/database/test-database-upgrade.php
@@ -92,9 +92,12 @@ class DatabaseTester {
 			$wpdb->insert( $wpdb->prefix . 'redirection_404', array( 'ip' => ip2long( '192.168.1.1' ) ) );
 			$wpdb->insert( $wpdb->prefix . 'redirection_404', array( 'ip' => ip2long( '203.168.1.5' ) ) );
 		} elseif ( $ver === '3.9' ) {
-			$wpdb->insert( $wpdb->prefix . 'redirection_items', array( 'url' => '/TEST/?thing=cat' ) );
-			$wpdb->insert( $wpdb->prefix . 'redirection_items', array( 'url' => '/' ) );
-			$wpdb->insert( $wpdb->prefix . 'redirection_items', array( 'url' => '/.*', 'regex' => 1 ) );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/TEST/?thing=cat' ] );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/' ] );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/.*', 'regex' => 1 ] );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '//' ] );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/thing///' ] );
+			$wpdb->insert( $wpdb->prefix . 'redirection_items', [ 'url' => '/index.php' ] );
 		}
 	}
 
@@ -108,12 +111,19 @@ class DatabaseTester {
 			$unit->assertEquals( '203.168.1.5', $rows[1]->ip );
 		} elseif ( $ver === '3.9' ) {
 			$rows = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_items" );
+
 			$unit->assertEquals( '/TEST/?thing=cat', $rows[0]->url );
 			$unit->assertEquals( '/test', $rows[0]->match_url );
+
 			$unit->assertEquals( '/', $rows[1]->url );
 			$unit->assertEquals( '/', $rows[1]->match_url );
+
 			$unit->assertEquals( '/.*', $rows[2]->url );
 			$unit->assertEquals( 'regex', $rows[2]->match_url );
+
+			$unit->assertEquals( '/', $rows[3]->match_url );
+			$unit->assertEquals( '/thing//', $rows[4]->match_url );
+			$unit->assertEquals( '/index.php', $rows[5]->match_url );
 		}
 	}
 }
@@ -396,7 +406,4 @@ class UpgradeDatabaseTest extends WP_UnitTestCase {
 		$existing = $wpdb->get_row( "SHOW CREATE TABLE `{$wpdb->prefix}redirection_404`", ARRAY_N );
 		$this->assertTrue( strpos( $existing[1], 'KEY `ip` (`ip`)' ) !== false );
 	}
-
-	// XXX add test for 2.3.3 => 2.4 when key `ip` (`id`) exists
-	// XXX have a 'build for release' task that removes all node_modules, builds from scratch, versions, locale, etc
 }

--- a/tests/database/test-database.php
+++ b/tests/database/test-database.php
@@ -167,7 +167,7 @@ class DatabaseTest extends WP_UnitTestCase {
 	public function testGetUpgradesForSameVersion() {
 		$database = new Red_Database();
 		$upgrades = $database->get_upgrades_for_version( '2.2', false );
-		$this->assertEquals( 5, count( $upgrades ) );
+		$this->assertEquals( 6, count( $upgrades ) );
 	}
 
 	public function testGetUpgradesForUnknownVersion() {

--- a/tests/fileio/test-apache.php
+++ b/tests/fileio/test-apache.php
@@ -77,10 +77,17 @@ class ApacheTest extends WP_UnitTestCase {
 
 	public function testRewriteNoCode() {
 		$apache = new Red_Apache_File();
-		$item = $apache->get_as_item( 'RewriteRule ^products/reporting /products/ [R,L]' );
+		$item = $apache->get_as_item( 'RewriteRule ^products/reporting$ /products/ [R,L]' );
 
 		$this->assertEquals( '/products/reporting', $item['url'] );
 		$this->assertEquals( array( 'url' => '/products/' ), $item['action_data'] );
 		$this->assertEquals( '302', $item['action_code'] );
+	}
+
+	public function testRedirectWithExtension() {
+		$apache = new Red_Apache_File();
+		$item = $apache->get_as_item( 'RewriteRule ^products/reporting\.html.*$ /products/ [R,L]' );
+
+		$this->assertEquals( '^/products/reporting\.html.*', $item['url'] );
 	}
 }

--- a/tests/models/test-url-path.php
+++ b/tests/models/test-url-path.php
@@ -22,4 +22,59 @@ class UrlPathTest extends WP_UnitTestCase {
 		$url = new Red_Url_Path( '/test1/' );
 		$this->assertTrue( $url->is_match( '/test1', new Red_Source_Flags( [ 'flag_trailing' => true ] ) ) );
 	}
+
+	public function testPathRelative() {
+		$url = new Red_Url_Path( '/cats?this=query&more' );
+		$this->assertEquals( '/cats', $url->get() );
+	}
+
+	public function testPathAbsolute() {
+		$url = new Red_Url_Path( 'http://domain.com:303/cats?this=query&more' );
+		$this->assertEquals( '/cats', $url->get() );
+	}
+
+	public function testPathDoubleSlash() {
+		$url = new Red_Url_Path( '//cats//?this=query&more' );
+		$this->assertEquals( '//cats//', $url->get() );
+	}
+
+	public function testRootQuery() {
+		$url = new Red_Url_Path( '/?this=query&more' );
+		$this->assertEquals( '/', $url->get() );
+	}
+
+	public function testRegexPath() {
+		$url = new Red_Url_Path( '/thing\\?this=query&more' );
+		$this->assertEquals( '/thing', $url->get() );
+	}
+
+	public function testRootQueryDouble() {
+		$url = new Red_Url_Path( '//?this=query&more' );
+		$this->assertEquals( '//', $url->get() );
+	}
+
+	public function testPathAbsoluteQueryParam() {
+		$url = new Red_Url_Path( '/page.html?page=http://domain.com:303/cats?this=query&more' );
+		$this->assertEquals( '/page.html', $url->get() );
+	}
+
+	public function testTrailingSlash() {
+		$url = new Red_Url_Path( '/' );
+		$this->assertEquals( '/', $url->get_without_trailing_slash() );
+	}
+
+	public function testDoubleTrailingSlash() {
+		$url = new Red_Url_Path( '//' );
+		$this->assertEquals( '//', $url->get_without_trailing_slash() );
+	}
+
+	public function testTrailingSlashLonger() {
+		$url = new Red_Url_Path( '/something/' );
+		$this->assertEquals( '/something', $url->get_without_trailing_slash() );
+	}
+
+	public function testTrailingSlashWithPath() {
+		$url = new Red_Url_Path( '/something//' );
+		$this->assertEquals( '/something/', $url->get_without_trailing_slash() );
+	}
 }

--- a/tests/models/test-url-query.php
+++ b/tests/models/test-url-query.php
@@ -32,13 +32,31 @@ class UrlQueryTest extends WP_UnitTestCase {
 	}
 
 	public function testQueryMatchIgnoreDefault() {
-		$url = new Red_Url_Query( 'a=1' );
+		$url = new Red_Url_Query( '/?a=1' );
 		$this->assertTrue( $url->is_match( '/this?b=2&a=1', new Red_Source_Flags( [ 'flag_query' => 'ignore' ] ) ) );
 	}
 
 	public function testQueryMatchIgnorePass() {
-		$url = new Red_Url_Query( 'a=1' );
+		$url = new Red_Url_Query( '/?a=1' );
 		$this->assertTrue( $url->is_match( '/this?b=2&a=1', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
+	}
+
+	public function testQueryMatchArray() {
+		$url = new Red_Url_Query( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3' );
+		$this->assertTrue( $url->is_match( '/this?arrs2[]=1&arrs2[]=2&arrs2[]=3&arrs1[]=1&arrs1[]=2&arrs1[]=3', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
+	}
+
+	public function testQueryNotMatchArray() {
+		$url = new Red_Url_Query( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=5' );
+		$this->assertFalse( $url->is_match( '/this?arrs2[]=1&arrs2[]=2&arrs2[]=3&arrs1[]=1&arrs1[]=2&arrs1[]=3', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
+	}
+
+	public function testQueryNotMatchArrayExact() {
+		$url = new Red_Url_Query( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3' );
+		$this->assertFalse( $url->is_match( '/this?arrs2[]=1&arrs2[]=2&arrs2[]=3&arrs1[]=1&arrs1[]=2&arrs1[]=3', new Red_Source_Flags() ) );
+
+		$url = new Red_Url_Query( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2=5' );
+		$this->assertFalse( $url->is_match( '/this?arrs2[]=1&arrs2[]=2&arrs2[]=3&arrs1[]=1&arrs1[]=2&arrs1[]=3', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
 	}
 
 	public function testQueryPassNoParams() {
@@ -61,4 +79,81 @@ class UrlQueryTest extends WP_UnitTestCase {
 	public function testQueryPassParamsNoOverride() {
 		$this->assertEquals( '/cats?cat=a', Red_Url_Query::add_to_target( '/cats?cat=a', '/target?cat=b', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
 	}
+
+	public function testQueryPassArray() {
+		$this->assertEquals( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3', Red_Url_Query::add_to_target( '/', '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
+	}
+
+	public function testQueryDoubleSlash() {
+		$url = new Red_Url_Query( '//?this=query&more' );
+		$this->assertEquals( [
+			'this' => 'query',
+			'more' => '',
+		], $url->get() );
+	}
+
+	public function testQueryUrl() {
+		$url = new Red_Url_Query( '//page.html?page=http://domain.com:303/cats?this=query&more' );
+		$this->assertEquals( [
+			'page' => 'http://domain.com:303/cats?this=query',
+			'more' => '',
+		], $url->get() );
+	}
+
+	public function testEscapedQueryUrlBefore() {
+		$url = new Red_Url_Query( '/page.html\\?page=http://domain.com:303/cats?this=query&more' );
+		$this->assertEquals( [
+			'page' => 'http://domain.com:303/cats?this=query',
+			'more' => '',
+		], $url->get() );
+	}
+
+	public function testEscapedQueryUrlAfter() {
+		$url = new Red_Url_Query( '/page.html?page=http://domain.com:303/cats\\?this=query&more' );
+		$this->assertEquals( [
+			'page' => 'http://domain.com:303/cats\\?this=query',
+			'more' => '',
+		], $url->get() );
+	}
+
+	public function testQueryPhpArray() {
+		$url = new Red_Url_Query( '/?thing=save&arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3' );
+		$this->assertEquals( [
+			'thing' => 'save',
+			'arrs1' => [ 1, 2, 3 ],
+			'arrs2' => [ 1, 2, 3 ],
+		], $url->get() );
+	}
+
+	public function testArraySame() {
+		$url = new Red_Url_Query( '' );
+		$this->assertEquals( [], $url->get_query_same( [], [] ) );
+		$this->assertEquals( [ 'a' => 'a' ], $url->get_query_same( [ 'a' => 'a' ], [ 'a' => 'a' ] ) );
+		$this->assertEquals( [ 'a' => '' ], $url->get_query_same( [ 'a' => '' ], [ 'a' => '' ] ) );
+		$this->assertEquals( [ 'a' => 'a' ], $url->get_query_same( [ 'a' => 'a', 'b' => 'b' ], [ 'a' => 'a' ] ) );
+		$this->assertEquals( [ 'a' => 'a' ], $url->get_query_same( [ 'a' => 'a' ], [ 'a' => 'a', 'b' => 'b' ] ) );
+	}
+
+	public function testArraySameDeep() {
+		$url = new Red_Url_Query( '' );
+		$this->assertEquals( [ 'a' => [ '1' => '1', '2' => '2' ] ], $url->get_query_same( [ 'a' => [ '1' => '1', '2' => '2' ] ], [ 'a' => [ '1' => '1', '2' => '2' ] ] ) );
+		$this->assertEquals( [], $url->get_query_same( [ 'a' => [ '1' => '1', '2' => '2' ] ], [ 'a' => [ '1' => '1' ] ] ) );
+	}
+
+	public function testArrayDiff() {
+		$url = new Red_Url_Query( '' );
+		$this->assertEquals( [], $url->get_query_diff( [], [] ) );
+		$this->assertEquals( [], $url->get_query_diff( [ 'a' => 'a' ], [ 'a' => 'a' ] ) );
+		$this->assertEquals( [ 'a' => 'a' ], $url->get_query_diff( [ 'a' => 'a' ], [] ) );
+		$this->assertEquals( [ 'a' => 'a' ], $url->get_query_diff( [ 'a' => 'a' ], [ 'b' => 'b' ] ) );
+	}
+
+	public function testArrayDiffDeep() {
+		$url = new Red_Url_Query( '' );
+		$this->assertEquals( [ 'a' => [ 'a' => 'a' ] ], $url->get_query_diff( [ 'a' => [ 'a' => 'a' ] ], [] ) );
+		$this->assertEquals( [], $url->get_query_diff( [ 'a' => [ 'a' => 'a' ] ], [ 'a' => [ 'a' => 'a' ] ] ) );
+		$this->assertEquals( [ 'a' => [ 'a' => 'a' ] ], $url->get_query_diff( [ 'a' => [ 'a' => 'a' ] ], [ 'a' => [ 'a' => 'b' ] ] ) );
+	}
 }
+
+// XXX put these into e2e tests

--- a/tests/models/test-url.php
+++ b/tests/models/test-url.php
@@ -16,6 +16,11 @@ class UrlTest extends WP_UnitTestCase {
 		$this->assertEquals( '/test', $url->get_url() );
 	}
 
+	public function testGetPlainUrlAnsoluteDouble() {
+		$url = new Red_Url_Match( 'http://test.com//test//' );
+		$this->assertEquals( '//test/', $url->get_url() );
+	}
+
 	public function testGetPlainUrlEmpty() {
 		$url = new Red_Url_Match( '' );
 		$this->assertEquals( '/', $url->get_url() );
@@ -31,13 +36,49 @@ class UrlTest extends WP_UnitTestCase {
 		$this->assertEquals( '/test', $url->get_url() );
 	}
 
-	public function testNotIsMatch() {
+	public function testNotIsMatchPlain() {
 		$url = new Red_Url( '/cats' );
 		$this->assertFalse( $url->is_match( '/bats', new Red_Source_Flags() ) );
 	}
 
-	public function testIsMatch() {
+	public function testIsMatchPlain() {
 		$url = new Red_Url( '/cats' );
 		$this->assertTrue( $url->is_match( '/cats', new Red_Source_Flags() ) );
+	}
+
+	public function testIsMatchQuery() {
+		$url = new Red_Url( '/cats?dogs=1' );
+		$this->assertTrue( $url->is_match( '/cats?dogs=1', new Red_Source_Flags() ) );
+
+		$url = new Red_Url( '/cats?dogs[]=1&dogs[]=2' );
+		$this->assertTrue( $url->is_match( '/cats?dogs[]=1&dogs[]=2', new Red_Source_Flags() ) );
+	}
+
+	public function testIsNotMatchQuery() {
+		$url = new Red_Url( '/cats?dogs[]=1&dogs[]=2' );
+		$this->assertFalse( $url->is_match( '/cats?dogs[]=3&dogs[]=2', new Red_Source_Flags() ) );
+
+		$url = new Red_Url( '/?order=wc_order_nq123124sdf0' );
+		$this->assertTrue( $url->is_match( '/?download_file=123&order=wc_order_nq123124sdf0&email=test%40example.com&key=5237f783-054ae-40db-aced-69bd011cdb3c', new Red_Source_Flags( [ 'flag_query' => 'ignore' ] ) ) );
+	}
+
+	public function testIsMatchDouble() {
+		$url = new Red_Url( '//' );
+		$this->assertTrue( $url->is_match( '//', new Red_Source_Flags() ) );
+	}
+
+	public function testIsMatchAbsolute() {
+		$url = new Red_Url( 'http://domain.com/cat/' );
+		$this->assertTrue( $url->is_match( '/cat/', new Red_Source_Flags() ) );
+	}
+
+	public function testIsMatchRegex() {
+		$url = new Red_Url( '/cat/\d' );
+		$this->assertTrue( $url->is_match( '/cat/1', new Red_Source_Flags( [ 'flag_regex' => true ] ) ) );
+	}
+
+	public function testIsMatchIgnoreQueryx() {
+		$url = new Red_Url( '/cat' );
+		$this->assertTrue( $url->is_match( '/cat?things', new Red_Source_Flags( [ 'flag_query' => 'ignore' ] ) ) );
 	}
 }


### PR DESCRIPTION
`parse_url` breaks on certain URLs, such as ones with a double slash.  Use own code to parse URLs