### PR TITLE
Fix regex and UTF8

### DIFF
--- a/models/regex.php
+++ b/models/regex.php
@@ -8,7 +8,7 @@ class Red_Regex {
 	private $case;
 
 	public function __construct( $pattern, $case_insensitive = false ) {
-		$this->pattern = $pattern;
+		$this->pattern = urldecode( $pattern );
 		$this->case = $case_insensitive;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,9 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 
 == Changelog ==
 
+= 4.3.2 - ??? ==
+* Fix problem with UTF8 characters in a regex URL
+
 = 4.3.1 - 8th June 2019 =
 * Fix + character being removed from source URL
 

--- a/tests/models/test-regex.php
+++ b/tests/models/test-regex.php
@@ -21,6 +21,12 @@ class RegexTest extends WP_UnitTestCase {
 		$this->assertFalse( $regex->is_match( 'DOG5' ) );
 	}
 
+	public function testDecode() {
+		$regex = new Red_Regex( urlencode( 'für.*' ) );
+
+		$this->assertTrue( $regex->is_match( 'fürcat' ) );
+	}
+
 	public function testQuoteRegex() {
 		$regex = new Red_Regex( '@cat.*' );
 

--- a/tests/models/test-url.php
+++ b/tests/models/test-url.php
@@ -81,6 +81,11 @@ class UrlTest extends WP_UnitTestCase {
 		$this->assertTrue( $url->is_match( '/cat/1', new Red_Source_Flags( [ 'flag_regex' => true ] ) ) );
 	}
 
+	public function testIsMatchEncodedRegex() {
+		$url = new Red_Url( urlencode( '/für/\d' ) );
+		$this->assertTrue( $url->is_match( '/für/1', new Red_Source_Flags( [ 'flag_regex' => true ] ) ) );
+	}
+
 	public function testIsMatchIgnoreQuery() {
 		$url = new Red_Url( '/cat' );
 		$this->assertTrue( $url->is_match( '/cat?things', new Red_Source_Flags( [ 'flag_query' => 'ignore' ] ) ) );


### PR DESCRIPTION
The match was comparing encode against unencoded. Decode so we compare the same

Fixes #1808 