### PR TITLE
Add import on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /.vscode
 /yarn-error.log
 /api-doc
+/vendor

--- a/api/api-404.php
+++ b/api/api-404.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @api {get} /redirection/v1/404 Get 404 logs
  * @apiName GetLogs

--- a/api/api-import.php
+++ b/api/api-import.php
@@ -38,7 +38,7 @@ class Redirection_Api_Import extends Redirection_Api_Route {
 			$this->get_route( WP_REST_Server::READABLE, 'route_plugin_import_list', [ $this, 'permission_callback_manage' ] ),
 		) );
 
-		register_rest_route( $namespace, '/import/plugin/(?P<plugin>.*?)', array(
+		register_rest_route( $namespace, '/import/plugin', array(
 			$this->get_route( WP_REST_Server::EDITABLE, 'route_plugin_import', [ $this, 'permission_callback_manage' ] ),
 		) );
 	}
@@ -48,17 +48,24 @@ class Redirection_Api_Import extends Redirection_Api_Route {
 	}
 
 	public function route_plugin_import_list( WP_REST_Request $request ) {
-		include_once dirname( dirname( __FILE__ ) ) . '/models/importer.php';
+		include_once dirname( __DIR__ ) . '/models/importer.php';
 
 		return array( 'importers' => Red_Plugin_Importer::get_plugins() );
 	}
 
 	public function route_plugin_import( WP_REST_Request $request ) {
-		include_once dirname( dirname( __FILE__ ) ) . '/models/importer.php';
+		include_once dirname( __DIR__ ) . '/models/importer.php';
 
+		$params = $request->get_params( $request );
 		$groups = Red_Group::get_all();
+		$plugins = is_array( $request['plugin'] ) ? $request['plugin'] : [ $request['plugin'] ];
+		$total = 0;
 
-		return array( 'imported' => Red_Plugin_Importer::import( $request['plugin'], $groups[0]['id'] ) );
+		foreach ( $plugins as $plugin ) {
+			$total += Red_Plugin_Importer::import( $plugin, $groups[0]['id'] );
+		}
+
+		return [ 'imported' => $total ];
 	}
 
 	public function route_import_file( WP_REST_Request $request ) {

--- a/api/api-redirect.php
+++ b/api/api-redirect.php
@@ -169,7 +169,7 @@
  * @apiParam (Query Parameter) {String="asc","desc"} direction Direction to order the results by (ascending or descending)
  * @apiParam (Query Parameter) {Integer{1...200}} per_page Number of results per request
  * @apiParam (Query Parameter) {Integer} page Current page of results
-  */
+ */
 class Redirection_Api_Redirect extends Redirection_Api_Filter_Route {
 	public function __construct( $namespace ) {
 		$orders = [ 'url', 'last_count', 'last_access', 'position', 'id' ];

--- a/client/component/database/index.js
+++ b/client/component/database/index.js
@@ -28,6 +28,7 @@ class Database extends React.Component {
 
 	static defaultProps = {
 		manual: false,
+		onFinished: null,
 	}
 
 	constructor( props ) {
@@ -76,9 +77,9 @@ class Database extends React.Component {
 
 		if ( this.props.onFinished ) {
 			this.props.onFinished();
+		} else {
+			this.props.onFinish();
 		}
-
-		this.props.onFinish();
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/component/menu/index.js
+++ b/client/component/menu/index.js
@@ -20,12 +20,12 @@ const getMenu = () => [
 		value: '',
 	},
 	{
-		name: __( 'Site' ),
-		value: 'site',
-	},
-	{
 		name: __( 'Groups' ),
 		value: 'groups',
+	},
+	{
+		name: __( 'Site' ),
+		value: 'site',
 	},
 	{
 		name: __( 'Log' ),

--- a/client/lib/api/index.js
+++ b/client/lib/api/index.js
@@ -124,7 +124,7 @@ export const RedirectionApi = {
 		get: () => getApiRequest( 'import' ),
 		upload: ( group, file ) => uploadApiRequest( 'import/file/' + group, file ),
 		pluginList: () => getApiRequest( 'import/plugin' ),
-		pluginImport: plugin => postApiRequest( 'import/plugin/' + plugin ),
+		pluginImport: plugin => postApiRequest( 'import/plugin', { plugin } ),
 	},
 	export: {
 		file: ( module, format ) => getApiRequest( 'export/' + module + '/' + format ),
@@ -143,7 +143,7 @@ export const RedirectionApi = {
 
 			return request;
 		},
-		matchPost: text => getApiRequest( 'plugin/post', { text } )
+		matchPost: text => getApiRequest( 'plugin/post', { text } ),
 	},
 	bulk: {
 		redirect: ( action, data, table ) => postApiRequest( 'bulk/redirect/' + action, data, table ),

--- a/client/state/info/__tests__/reducer.js
+++ b/client/state/info/__tests__/reducer.js
@@ -15,6 +15,7 @@ import {
 import { getInitialIO } from 'state/io/initial';
 import { STATUS_IN_PROGRESS, STATUS_FAILED, STATUS_COMPLETE } from 'state/settings/type';
 
+global.Redirectioni10n = {};
 const DEFAULT_STATE = getInitialIO();
 
 jest.mock( 'lib/store' );

--- a/client/state/io/__tests__/reducer.js
+++ b/client/state/io/__tests__/reducer.js
@@ -15,6 +15,7 @@ import {
 import { getInitialIO } from 'state/io/initial';
 import { STATUS_IN_PROGRESS, STATUS_FAILED, STATUS_COMPLETE } from 'state/settings/type';
 
+global.Redirectioni10n = {};
 const DEFAULT_STATE = getInitialIO();
 
 jest.mock( 'lib/store' );

--- a/client/state/io/initial.js
+++ b/client/state/io/initial.js
@@ -1,8 +1,17 @@
+/* global Redirectioni10n */
 /**
  * Internal dependencies
  */
 
 import { STATUS_IN_PROGRESS } from 'state/settings/type';
+
+function getPreload() {
+	if ( Redirectioni10n && Redirectioni10n.preload && Redirectioni10n.preload.importers ) {
+		return Redirectioni10n.preload.importers;
+	}
+
+	return [];
+}
 
 export function getInitialIO() {
 	return {
@@ -12,6 +21,6 @@ export function getInitialIO() {
 		exportData: false,
 		importingStatus: false,
 		exportStatus: false,
-		importers: [],
+		importers: getPreload(),
 	};
 }

--- a/client/state/settings/action.js
+++ b/client/state/settings/action.js
@@ -1,4 +1,3 @@
-/* global fetch */
 /**
  * Internal dependencies
  */

--- a/client/state/settings/reducer.js
+++ b/client/state/settings/reducer.js
@@ -23,6 +23,11 @@ import {
 	STATUS_COMPLETE,
 	STATUS_FAILED,
 } from './type';
+import { IO_IMPORTED, IO_FAILED } from 'state/io/type';
+
+const DB_STATUS_OK = 'ok';
+const DB_STATUS_LOADING = 'loading';
+const DB_STATUS_FAIL = 'fail';
 
 function setApiTest( existing, id, method, result ) {
 	const api = existing[ id ] ? { ... existing[ id ] } : [];
@@ -35,22 +40,24 @@ function setApiTest( existing, id, method, result ) {
 export default function settings( state = {}, action ) {
 	switch ( action.type ) {
 		case SETTING_API_TRY:
-			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: 'loading' } ) } };
+			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: DB_STATUS_LOADING } ) } };
 
 		case SETTING_API_SUCCESS:
-			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: 'ok' } ) } };
+			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: DB_STATUS_OK } ) } };
 
 		case SETTING_API_FAILED:
-			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: 'fail', error: action.error } ) } };
+			return { ... state, apiTest: { ... state.apiTest, ... setApiTest( state.apiTest, action.id, action.method, { status: DB_STATUS_FAIL, error: action.error } ) } };
 
 		case SETTING_DATABASE_SHOW:
 			return { ... state, showDatabase: true };
 
+		case IO_FAILED:
+		case IO_IMPORTED:
 		case SETTING_DATABASE_FINISH:
-			return { ... state, showDatabase: false, database: { ... state.database, status: 'ok' } };
+			return { ... state, showDatabase: false, database: { ... state.database, status: DB_STATUS_OK } };
 
 		case SETTING_DATABASE_START:
-			return { ... state, database: { ... state.database, inProgress: true, result: 'ok', reason: action.arg === 'skip' ? false : state.database.reason }, showDatabase: action.arg === 'stop' ? false : true };
+			return { ... state, database: { ... state.database, inProgress: true, result: DB_STATUS_OK, reason: action.arg === 'skip' ? false : state.database.reason }, showDatabase: action.arg === 'stop' ? false : true };
 
 		case SETTING_DATABASE_SUCCESS:
 			return { ... state, database: { ... state.database, ... action.database } };

--- a/models/action.php
+++ b/models/action.php
@@ -4,7 +4,7 @@ abstract class Red_Action {
 	protected $code;
 	protected $type;
 
-	function __construct( $values ) {
+	public function __construct( $values ) {
 		if ( is_array( $values ) ) {
 			foreach ( $values as $key => $value ) {
 				$this->$key = $value;
@@ -12,7 +12,7 @@ abstract class Red_Action {
 		}
 	}
 
-	static function create( $name, $code ) {
+	public static function create( $name, $code ) {
 		$avail = self::available();
 
 		if ( isset( $avail[ $name ] ) ) {
@@ -28,7 +28,7 @@ abstract class Red_Action {
 		return false;
 	}
 
-	static function available() {
+	public static function available() {
 		return array(
 			'url'     => array( 'url.php', 'Url_Action' ),
 			'error'   => array( 'error.php', 'Error_Action' ),

--- a/models/file-io.php
+++ b/models/file-io.php
@@ -96,6 +96,6 @@ abstract class Red_FileIO {
 		return false;
 	}
 
-	abstract function get_data( array $items, array $groups );
-	abstract function load( $group, $filename, $data );
+	abstract public function get_data( array $items, array $groups );
+	abstract public function load( $group, $filename, $data );
 }

--- a/models/fixer.php
+++ b/models/fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once dirname( REDIRECTION_FILE ) . '/database/database.php';
+require_once dirname( REDIRECTION_FILE ) . '/database/database.php';
 
 class Red_Fixer {
 	public function get_json() {

--- a/models/htaccess.php
+++ b/models/htaccess.php
@@ -225,13 +225,13 @@ class Red_Htaccess {
 			return '';
 		}
 
-		$text[] = '# Created by Redirection';
-		$text[] = '# ' . date( 'r' );
-		$text[] = '# Redirection ' . trim( $version['Version'] ) . ' - https://redirection.me';
-		$text[] = '';
-
-		// mod_rewrite section
-		$text[] = '<IfModule mod_rewrite.c>';
+		$text = [
+			'# Created by Redirection',
+			'# ' . date( 'r' ),
+			'# Redirection ' . trim( $version['Version'] ) . ' - https://redirection.me',
+			'',
+			'<IfModule mod_rewrite.c>',
+		];
 
 		// Add http => https option
 		$options = red_get_options();

--- a/models/importer.php
+++ b/models/importer.php
@@ -13,7 +13,7 @@ class Red_Plugin_Importer {
 		);
 
 		foreach ( $importers as $importer ) {
-			$importer = Red_Plugin_Importer::get_importer( $importer );
+			$importer = self::get_importer( $importer );
 			$results[] = $importer->get_data();
 		}
 
@@ -45,7 +45,7 @@ class Red_Plugin_Importer {
 	}
 
 	public static function import( $plugin, $group_id ) {
-		$importer = Red_Plugin_Importer::get_importer( $plugin );
+		$importer = self::get_importer( $plugin );
 		if ( $importer ) {
 			return $importer->import_plugin( $group_id );
 		}

--- a/models/importer.php
+++ b/models/importer.php
@@ -70,7 +70,9 @@ class Red_RankMath_Importer extends Red_Plugin_Importer {
 	}
 
 	private function create_for_item( $group_id, $redirect ) {
+		// phpcs:ignore
 		$sources = unserialize( $redirect->sources );
+		$items = [];
 
 		foreach ( $sources as $source ) {
 			$url = $source['pattern'];
@@ -102,7 +104,7 @@ class Red_RankMath_Importer extends Red_Plugin_Importer {
 		}
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
-			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		$total = 0;

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -264,7 +264,7 @@ class Red_Item {
 			return new WP_Error( 'redirect_create_failed', 'Unable to get newly added redirect' );
 		}
 
-		return new WP_Error( 'redirect_create_failed', __( 'Unable to add new redirect' ) );
+		return new WP_Error( 'redirect_create_failed', 'Unable to add new redirect' );
 	}
 
 	public function update( $details ) {

--- a/models/url-flags.php
+++ b/models/url-flags.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Represent URL source flags
+ * Represent URL source flags.
  */
 class Red_Source_Flags {
 	const QUERY_IGNORE = 'ignore';
@@ -34,9 +34,9 @@ class Red_Source_Flags {
 	}
 
 	/**
-	 * Parse flag data
+	 * Parse flag data.
 	 *
-	 * @param array $json Flag data
+	 * @param array $json Flag data.
 	 */
 	public function set_flags( array $json ) {
 		if ( isset( $json[ self::FLAG_QUERY ] ) && in_array( $json[ self::FLAG_QUERY ], $this->get_allowed_query(), true ) ) {
@@ -98,7 +98,9 @@ class Red_Source_Flags {
 	}
 
 	/**
-	 * Return flag data, with defaults removed from the data
+	 * Return flag data, with defaults removed from the data.
+	 *
+	 * @param array $defaults Defaults to remove.
 	 */
 	public function get_json_without_defaults( $defaults ) {
 		$json = $this->get_json();
@@ -115,7 +117,7 @@ class Red_Source_Flags {
 	}
 
 	/**
-	 * Return flag data, with defaults filling in any gaps not set
+	 * Return flag data, with defaults filling in any gaps not set.
 	 */
 	public function get_json_with_defaults() {
 		$settings = red_get_options();

--- a/models/url-path.php
+++ b/models/url-path.php
@@ -21,8 +21,8 @@ class Red_Url_Path {
 
 		if ( $flags->is_ignore_case() ) {
 			// Case insensitive match
-			$source_path = Red_Url_Path::to_lower( $source_path );
-			$target_path = Red_Url_Path::to_lower( $target_path );
+			$source_path = self::to_lower( $source_path );
+			$target_path = self::to_lower( $target_path );
 		}
 
 		return $target_path === $source_path;

--- a/models/url-query.php
+++ b/models/url-query.php
@@ -47,12 +47,12 @@ class Red_Url_Query {
 	}
 
 	/**
-	 * Pass query params from one URL to another URL, ignoring any params that already exist on the target
+	 * Pass query params from one URL to another URL, ignoring any params that already exist on the target.
 	 *
-	 * @param string $target_url The target URL to add params to
-	 * @param string $requested_url The source URL to pass params from
-	 * @param Red_Source_Flags $flags Any URL flags
-	 * @return string URL, modified or not
+	 * @param string $target_url The target URL to add params to.
+	 * @param string $requested_url The source URL to pass params from.
+	 * @param Red_Source_Flags $flags Any URL flags.
+	 * @return string URL, modified or not.
 	 */
 	public static function add_to_target( $target_url, $requested_url, Red_Source_Flags $flags ) {
 		if ( $flags->is_query_pass() && $target_url ) {

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -17,23 +17,31 @@ class WordPress_Module extends Red_Module {
 	public function start() {
 		// Only run redirect rules if we're not disabled
 		if ( ! red_is_disabled() ) {
+			// The main redirect loop
 			add_action( 'init', [ $this, 'init' ] );
-			add_action( 'send_headers', [ $this, 'send_headers' ] );
+
+			// Force HTTPs code
 			add_action( 'init', [ $this, 'force_https' ] );
+
+			// Send site HTTP headers as well as 410 error codes
+			add_action( 'send_headers', [ $this, 'send_headers' ] );
+
+			// Redirect HTTP headers and server-specific overrides
 			add_filter( 'wp_redirect', [ $this, 'wp_redirect' ], 1, 2 );
 		}
 
 		// Setup the various filters and actions that allow Redirection to happen
 		add_action( 'redirection_visit', [ $this, 'redirection_visit' ], 10, 3 );
 		add_action( 'redirection_do_nothing', [ $this, 'redirection_do_nothing' ] );
-		add_filter( 'redirect_canonical', [ $this, 'redirect_canonical' ], 10, 2 );
-		add_action( 'template_redirect', [ $this, 'template_redirect' ] );
 
-		// Remove WordPress 2.3 redirection
-		remove_action( 'template_redirect', 'wp_old_slug_redirect' );
+		// Prevent WordPress overriding a canonical redirect
+		add_filter( 'redirect_canonical', [ $this, 'redirect_canonical' ], 10, 2 );
+
+		// Log 404s and perform 'URL and WordPress page type' redirects
+		add_action( 'template_redirect', [ $this, 'template_redirect' ] );
 	}
 
-	/**
+	/*
 	 * This ensures that a matched URL is not overriddden by WordPress, if the URL happens to be a WordPress URL of some kind
 	 * For example: /?author=1 will be redirected to /author/name unless this returns false
 	 */
@@ -143,7 +151,7 @@ class WordPress_Module extends Red_Module {
 		}
 	}
 
-	/**
+	/*
 	 * Protect certain URLs from being redirected. Note we don't need to protect wp-admin, as this code doesn't run there
 	 */
 	private function protected_url( $url ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,431 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Gutenberg Plugin">
+	<description>Coding standard for Redirection plugin. Based on WordPress coding standards, but without the annoying Yoda and alignment options</description>
+
+	<rule ref="PHPCompatibility"/>
+	<config name="testVersion" value="5.6-"/>
+
+	<rule ref="WordPress-Core">
+		<!-- these I dont like -->
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning"/>
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+
+		<!-- documentation warnings -->
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
+		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle"/>
+		<exclude name="Squiz.Commenting.FunctionComment.WrongStyle"/>
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
+		<exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+	</rule>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress.WP.I18n"/>
+	<config name="text_domain" value="redirection,default"/>
+
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<properties>
+			<property name="allowMultipleArguments" value="false"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.I18n.MissingArgDomainDefault" />
+
+	<arg value="ps"/>
+	<arg name="extensions" value="php"/>
+	<arg name="colors"/>
+    <arg name="tab-width" value="4"/>
+
+
+
+
+
+
+
+	<rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Generic.Functions.CallTimePassByReference"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+    <rule ref="Generic.Classes.DuplicateClassName"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.PHP.NonExecutableCode"/>
+    <rule ref="Squiz.Operators.IncrementDecrementUsage"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+    <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
+    <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
+    <rule ref="PEAR.Files.IncludingFile"/>
+    <rule ref="PEAR.Files.IncludingFile.UseInclude">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
+        <type>warning</type>
+    </rule>
+    <rule ref="PEAR.Files.IncludingFile.UseRequire">
+        <type>warning</type>
+    </rule>
+    <rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.Scope.MemberVarScope"/>
+    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+    <rule ref="PSR2.Methods.MethodDeclaration"/>
+    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+        <type>warning</type>
+    </rule>
+	    <rule ref="WordPress.Security.EscapeOutput"/>
+
+    <!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1264 -->
+    <rule ref="WordPress.Security.SafeRedirect"/>
+
+    <!-- Verify that a nonce check is done before using values in superglobals.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/73 -->
+    <rule ref="WordPress.Security.NonceVerification"/>
+
+    <rule ref="WordPress.PHP.DevelopmentFunctions"/>
+    <rule ref="WordPress.PHP.DiscouragedPHPFunctions"/>
+    <rule ref="WordPress.WP.DeprecatedFunctions"/>
+    <rule ref="WordPress.WP.DeprecatedClasses"/>
+    <rule ref="WordPress.WP.DeprecatedParameters"/>
+    <rule ref="WordPress.WP.DeprecatedParameterValues"/>
+    <rule ref="WordPress.WP.AlternativeFunctions"/>
+    <rule ref="WordPress.WP.DiscouragedConstants"/>
+    <rule ref="WordPress.WP.DiscouragedFunctions"/>
+    <rule ref="WordPress.WP.EnqueuedResources"/>
+
+    <!-- Warn against overriding WP global variables.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/26 -->
+    <rule ref="WordPress.WP.GlobalVariablesOverride"/>
+
+    <!-- Encourage the use of strict ( === and !== ) comparisons.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/242 -->
+    <rule ref="WordPress.PHP.StrictComparisons"/>
+
+        <!-- Check that in_array() and array_search() use strict comparisons.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/399
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/503 -->
+    <rule ref="WordPress.PHP.StrictInArray"/>
+
+    <!-- Make the translators comment check which is included in core stricter. -->
+    <rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
+        <type>error</type>
+    </rule>
+    <rule ref="WordPress.WP.I18n.TranslatorsCommentWrongStyle">
+        <type>error</type>
+    </rule>
+    <!-- Verify that everything in the global namespace is prefixed. -->
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
+
+    <!-- Check that object instantiations always have braces & are not assigned by reference.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/919 -->
+    <rule ref="WordPress.Classes.ClassInstantiation"/>
+
+    <!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1157 -->
+    <rule ref="WordPress.Security.PluginMenuSlug"/>
+    <rule ref="WordPress.WP.CronInterval"/>
+    <rule ref="WordPress.WP.PostsPerPage"/>
+	<rule ref="WordPress.PHP.PregQuoteDelimiter"/>
+
+    <!-- The Core ruleset respects the whitelist. For `Extra` the sniff is stricter.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1450 -->
+    <rule ref="WordPress.PHP.NoSilencedErrors">
+        <properties>
+            <property name="use_default_whitelist" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Commented out code should not be committed.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1463 -->
+    <rule ref="Squiz.PHP.CommentedOutCode">
+        <properties>
+            <property name="maxPercentage" value="40"/>
+        </properties>
+    </rule>
+
+    <!-- Check for single blank line after namespace declaration. -->
+    <rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
+
+    <!-- Check enqueue and register styles and scripts to have version and in_footer parameters explicitly set.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1146 -->
+    <rule ref="WordPress.WP.EnqueuedResourceParameters"/>
+
+    <!-- Discourage use of the backtick operator (execution of shell commands).
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/646 -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+
+    <!-- Check for PHP Parse errors.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/522 -->
+    <rule ref="Generic.PHP.Syntax"/>
+
+    <!-- Covers rule: Use single and double quotes when appropriate.
+         If you're not evaluating anything in the string, use single quotes. -->
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+        <severity>0</severity>
+    </rule>
+	    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="exact" value="false"/>
+            <property name="indent" value="4"/>
+            <property name="tabIndent" value="true"/>
+            <property name="ignoreIndentationTokens" type="array" value="T_HEREDOC,T_NOWDOC,T_INLINE_HTML"/>
+        </properties>
+    </rule>
+    <rule ref="WordPress.Arrays.ArrayIndentation"/>
+
+    <!-- Covers rule: Use real tabs and not spaces. -->
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+    <rule ref="WordPress.WhiteSpace.PrecisionAlignment"/>
+
+    <!-- Generic array layout check. -->
+    <!-- Covers rule: For associative arrays, values should start on a new line.
+         Also covers various single-line array whitespace issues. -->
+    <rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
+
+    <!-- Covers rule: Note the comma after the last array item: this is recommended. -->
+    <rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
+
+    <!-- Covers rule: For switch structures case should indent one tab from the
+         switch statement and break one tab from the case statement. -->
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration">
+        <!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.NotLower"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine"/>
+    </rule>
+
+    <!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
+    <rule ref="WordPress.WhiteSpace.DisallowInlineTabs"/>
+	    <rule ref="Squiz.ControlStructures.ControlSignature"/>
+
+    <!-- Covers rule: Braces should always be used, even when they are not required. -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Regular Expressions.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#regular-expressions
+    #############################################################################
+    -->
+    <!-- Covers rule: Perl compatible regular expressions should be used in preference
+         to their POSIX counterparts. -->
+    <rule ref="WordPress.PHP.POSIXFunctions"/>
+
+    <!-- Rule: Never use the /e switch, use preg_replace_callback instead.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/632 -->
+
+    <!-- Rule: It's most convenient to use single-quoted strings for regular expressions.
+         Already covered by Squiz.Strings.DoubleQuoteUsage -->
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Opening and Closing PHP Tags.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#opening-and-closing-php-tags
+    #############################################################################
+    -->
+    <!-- Covers rule: When embedding multi-line PHP snippets within a HTML block, the
+         PHP open and close tags must be on a line by themselves. -->
+    <rule ref="Squiz.PHP.EmbeddedPhp">
+        <exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
+        <exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
+        <exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
+        <exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
+    </rule>
+	    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
+
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Remove Trailing Spaces.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#remove-trailing-spaces
+    #############################################################################
+    -->
+    <!-- Covers rule: Remove trailing whitespace at the end of each line of code. -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+
+    <!-- Covers rule: Omitting the closing PHP tag at the end of a file is preferred. -->
+    <rule ref="PSR2.Files.ClosingTag"/>
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Space Usage.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+    #############################################################################
+    -->
+    <!-- Covers rule: Always put spaces after commas, and on both sides of logical,
+         comparison, string and assignment operators. -->
+    <rule ref="WordPress.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Covers rule: Put spaces on both sides of the opening and closing parenthesis of
+         if, elseif, foreach, for, and switch blocks. -->
+    <rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
+
+
+    <!-- Covers rule: Define a function like so: function my_function( $param1 = 'foo', $param2 = 'bar' ) { -->
+    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+        <properties>
+            <property name="checkClosures" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+            <property name="requiredSpacesAfterOpen" value="1"/>
+            <property name="requiredSpacesBeforeClose" value="1"/>
+        </properties>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose"/>
+    </rule>
+
+    <!-- Covers rule: Call a function, like so: my_function( $param1, func_param( $param2 ) ); -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="requiredSpacesAfterOpen" value="1"/>
+            <property name="requiredSpacesBeforeClose" value="1"/>
+        </properties>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+        <severity phpcs-only="true">0</severity>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+        <severity phpcs-only="true">0</severity>
+    </rule>
+
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+
+    <!-- Rule: Perform logical comparisons, like so: if ( ! $foo ) { -->
+
+    <!-- Covers rule: When type casting, do it like so: $foo = (boolean) $bar; -->
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+    <rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
+
+    <!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
+    <rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
+
+    <!-- Rule: In a switch block, there must be no space before the colon for a case statement. -->
+    <!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
+
+    <!-- Rule: Similarly, there should be no space before the colon on return type declarations. -->
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Formatting SQL statements.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#formatting-sql-statements
+    #############################################################################
+    -->
+    <!-- Rule: Always capitalize the SQL parts of the statement like UPDATE or WHERE.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/639 -->
+
+    <!-- Rule: Functions that update the database should expect their parameters to lack
+         SQL slash escaping when passed.
+         https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/640 -->
+
+    <!-- Rule: in $wpdb->prepare - only %s and %d are used as placeholders. Note that they are not "quoted"! -->
+    <rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
+
+    <!-- Covers rule: Escaping should be done as close to the time of the query as possible,
+         preferably by using $wpdb->prepare() -->
+    <rule ref="WordPress.DB.PreparedSQL"/>
+   <rule ref="WordPress.DB.RestrictedFunctions"/>
+    <rule ref="WordPress.DB.RestrictedClasses"/>
+
+
+    <!--
+    #############################################################################
+    Handbook: PHP - Naming Conventions.
+    Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions
+    #############################################################################
+    -->
+    <!-- Covers rule: Use lowercase letters in variable, action, and function names.
+         Separate words via underscores. -->
+    <rule ref="WordPress.NamingConventions.ValidFunctionName"/>
+    <rule ref="WordPress.NamingConventions.ValidHookName"/>
+    <rule ref="WordPress.NamingConventions.ValidVariableName"/>
+
+    <!-- Covers rule: Class names should use capitalized words separated by underscores. -->
+    <rule ref="PEAR.NamingConventions.ValidClassName"/>
+
+    <!-- Covers rule: Constants should be in all upper-case with underscores separating words. -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+    <rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+    <!-- Rule: In a switch statement... If a case contains a block, then falls through
+         to the next block, this must be explicitly commented. -->
+    <!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
+
+    <!-- Rule: The eval() construct is very dangerous, and is impossible to secure. ... these must not be used. -->
+    <rule ref="Squiz.PHP.Eval"/>
+    <rule ref="Squiz.PHP.Eval.Discouraged">
+        <type>error</type>
+        <message>eval() is a security risk so not allowed.</message>
+    </rule>
+
+    <!-- Rule: create_function() function, which internally performs an eval(),
+         is deprecated in PHP 7.2. Both of these must not be used. -->
+    <rule ref="WordPress.PHP.RestrictedPHPFunctions"/>
+
+
+
+	<file>./models</file>
+	<!-- <file>./modules</file>
+	<file>./matches</file>
+	<file>./fileio</file>
+	<file>./database</file>
+	<file>./api</file> -->
+	<file>./redirection-admin.php</file>
+	<file>./redirection-capabilities.php</file>
+	<file>./redirection-front.php</file>
+	<file>./redirection-settings.php</file>
+	<file>./redirection.php</file>
+
+	<!-- Ignore snake case error in parser -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase">
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase">
+	</rule>
+	<!-- Ignore filename error since it requires WP core build process change -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+	</rule>
+</ruleset>

--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -76,10 +76,10 @@ class Redirection_Admin {
 		$message = false;
 		if ( $status->needs_installing() ) {
 			/* translators: 1: URL to plugin page */
-			$message = sprintf( __( 'Please complete your <a href="%s">Redirection setup</a> to activate the plugin.' ), esc_url( $this->get_plugin_url() ) );
+			$message = sprintf( __( 'Please complete your <a href="%s">Redirection setup</a> to activate the plugin.', 'redirection' ), esc_url( $this->get_plugin_url() ) );
 		} elseif ( $status->needs_updating() ) {
 			/* translators: 1: URL to plugin page, 2: current version, 3: target version */
-			$message = sprintf( __( 'Redirection\'s database needs to be updated - <a href="%1$1s">click to update</a>.' ), esc_url( $this->get_plugin_url() ) );
+			$message = sprintf( __( 'Redirection\'s database needs to be updated - <a href="%1$1s">click to update</a>.', 'redirection' ), esc_url( $this->get_plugin_url() ) );
 		}
 
 		if ( ! $message || strpos( Redirection_Request::get_request_url(), 'page=redirection.php' ) !== false ) {
@@ -257,7 +257,7 @@ class Redirection_Admin {
 		add_filter( 'ip-geo-block-admin', array( $this, 'ip_geo_block' ) );
 	}
 
-	/**
+	/*
 	 * This works around the IP Geo Block plugin being very aggressive and breaking Redirection
 	 */
 	public function ip_geo_block( $validate ) {
@@ -312,7 +312,7 @@ class Redirection_Admin {
 			);
 		}
 
-		return array();
+		return [];
 	}
 
 	private function add_help_tab() {
@@ -404,6 +404,8 @@ class Redirection_Admin {
 	}
 
 	private function show_minimum_wordpress() {
+		global $wp_version;
+
 		/* translators: 1: Expected WordPress version, 2: Actual WordPress version */
 		$wp_requirement = sprintf( __( 'Redirection requires WordPress v%1$1s, you are using v%2$2s - please update your WordPress', 'redirection' ), REDIRECTION_MIN_WP, $wp_version );
 		?>
@@ -496,12 +498,12 @@ class Redirection_Admin {
 	}
 
 	/**
-	 * Get the current plugin page
-	 * Uses $_GET['sub'] to determine the current page unless a page is supplied
+	 * Get the current plugin page.
+	 * Uses $_GET['sub'] to determine the current page unless a page is supplied.
 	 *
-	 * @param string $page Current page
+	 * @param string $page Current page.
 	 *
-	 * @return string|boolean Current page, or false
+	 * @return string|boolean Current page, or false.
 	 */
 	private function get_current_page( $page = false ) {
 		// $_GET['sub'] is validated below

--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -302,6 +302,16 @@ class Redirection_Admin {
 	}
 
 	private function get_preload_data() {
+		$status = new Red_Database_Status();
+
+		if ( $status->needs_installing() ) {
+			include_once __DIR__ . '/models/importer.php';
+
+			return [
+				'importers' => Red_Plugin_Importer::get_plugins(),
+			];
+		}
+
 		if ( $this->get_current_page() === 'support' ) {
 			require_once dirname( REDIRECTION_FILE ) . '/models/fixer.php';
 

--- a/redirection-capabilities.php
+++ b/redirection-capabilities.php
@@ -70,9 +70,9 @@ class Redirection_Capabilities {
 	const CAP_SITE_MANAGE = 'redirection_cap_site_manage';
 
 	/**
-	 * Determine if the current user has access to a named capability
+	 * Determine if the current user has access to a named capability.
 	 *
-	 * @param string $cap The capability to check for. See Redirection_Capabilities for constants
+	 * @param string $cap_name The capability to check for. See Redirection_Capabilities for constants.
 	 * @return boolean
 	 */
 	public static function has_access( $cap_name ) {

--- a/redirection-cli.php
+++ b/redirection-cli.php
@@ -20,6 +20,7 @@ class Redirection_Cli extends WP_CLI_Command {
 
 		return false;
 	}
+
 	/**
 	 * Get or set a Redirection setting
 	 *
@@ -152,6 +153,7 @@ class Redirection_Cli extends WP_CLI_Command {
 			$export = Red_FileIO::export( $args[0], $format );
 
 			if ( $export === false ) {
+				// phpcs:ignore
 				WP_CLI::error( 'Invalid module - must be wordpress, apache, nginx, or all' );
 				return;
 			}
@@ -238,10 +240,10 @@ class Redirection_Cli extends WP_CLI_Command {
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	WP_CLI::add_command( 'redirection import', array( 'Redirection_Cli', 'import' ) );
-	WP_CLI::add_command( 'redirection export', array( 'Redirection_Cli', 'export' ) );
-	WP_CLI::add_command( 'redirection database', array( 'Redirection_Cli', 'database' ) );
-	WP_CLI::add_command( 'redirection setting', array( 'Redirection_Cli', 'setting' ) );
+	WP_CLI::add_command( 'redirection import', [ 'Redirection_Cli', 'import' ] );
+	WP_CLI::add_command( 'redirection export', [ 'Redirection_Cli', 'export' ] );
+	WP_CLI::add_command( 'redirection database', [ 'Redirection_Cli', 'database' ] );
+	WP_CLI::add_command( 'redirection setting', [ 'Redirection_Cli', 'setting' ] );
 
 	add_action( Red_Flusher::DELETE_HOOK, function() {
 		$flusher = new Red_Flusher();

--- a/redirection-front.php
+++ b/redirection-front.php
@@ -1,13 +1,13 @@
 <?php
 
-include_once dirname( __FILE__ ) . '/modules/wordpress.php';
-include_once dirname( __FILE__ ) . '/database/database-status.php';
+require_once __DIR__ . '/modules/wordpress.php';
+require_once __DIR__ . '/database/database-status.php';
 
 class Redirection {
 	private static $instance = null;
 	private $module;
 
-	static function init() {
+	public static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Redirection();
 		}
@@ -51,8 +51,10 @@ class Redirection {
 		$ip = trim( $ip );
 
 		if ( strpos( $ip, ':' ) !== false ) {
+			// phpcs:ignore
 			$ip = @inet_pton( trim( $ip ) );
 
+			// phpcs:ignore
 			return @inet_ntop( $ip & pack( 'a16', 'ffff:ffff:ffff:ffff::ff00::0000::0000::0000' ) );
 		}
 
@@ -73,9 +75,7 @@ class Redirection {
 		$flusher->flush();
 	}
 
-	/**
-	 * From the distant Redirection past. Undecided whether to keep
-	 */
+	// From the distant Redirection past. Undecided whether to keep
 	public function replace_special_tags( $url ) {
 		if ( is_numeric( $url ) ) {
 			$url = get_permalink( $url );
@@ -92,9 +92,7 @@ class Redirection {
 		return $url;
 	}
 
-	/**
-	 * Used for unit tests
-	 */
+	// Used for unit tests
 	public function get_module() {
 		return $this->module;
 	}

--- a/redirection-settings.php
+++ b/redirection-settings.php
@@ -17,7 +17,7 @@ function red_get_post_types( $full = true ) {
 	$types = get_post_types( array( 'public' => true ), 'objects' );
 	$types[] = (object) array(
 		'name' => 'trash',
-		'label' => __( 'Trash' ),
+		'label' => __( 'Trash', 'default' ),
 	);
 
 	$post_types = array();
@@ -70,7 +70,7 @@ function red_set_options( array $settings = array() ) {
 		$options['database'] = $settings['database'];
 	}
 
-	if ( isset( $settings['rest_api'] ) && in_array( intval( $settings['rest_api'], 10 ), array( 0, 1, 2, 3, 4 ) ) ) {
+	if ( isset( $settings['rest_api'] ) && in_array( intval( $settings['rest_api'], 10 ), array( 0, 1, 2, 3, 4 ), true ) ) {
 		$options['rest_api'] = intval( $settings['rest_api'], 10 );
 	}
 
@@ -78,7 +78,7 @@ function red_set_options( array $settings = array() ) {
 		$allowed = red_get_post_types( false );
 
 		foreach ( $settings['monitor_types'] as $type ) {
-			if ( in_array( $type, $allowed ) ) {
+			if ( in_array( $type, $allowed, true ) ) {
 				$monitor_types[] = $type;
 			}
 		}

--- a/tests/api/test-import.php
+++ b/tests/api/test-import.php
@@ -5,7 +5,7 @@ class ImportImportCsvTest extends Redirection_Api_Test {
 		return [
 			[ 'import/file/1', 'POST', [] ],
 			[ 'import/plugin', 'GET', [] ],
-			[ 'import/plugin/thing', 'POST', [] ],
+			[ 'import/plugin', 'POST', [ 'plugin' => [ 'thing' ] ] ],
 		];
 	}
 
@@ -21,7 +21,7 @@ class ImportImportCsvTest extends Redirection_Api_Test {
 		$working = [
 			Redirection_Capabilities::CAP_IO_MANAGE => [
 				[ 'import/plugin', 'GET' ],
-				[ 'import/plugin/thing', 'POST' ],
+				[ 'import/plugin', 'POST' ],
 				[ 'import/file/1', 'POST' ],
 			],
 		];


### PR DESCRIPTION
This adds an import step in the install wizard. It also stops disabling WordPress old slug redirects as Redirection now co-exists with these without issue.

Fixes #1259