### PR TITLE
Fix encoded parameters in target

### DIFF
--- a/e2e/__tests__/url.json
+++ b/e2e/__tests__/url.json
@@ -399,5 +399,31 @@
 				"agent": true
 			}
 		}
+	],
+	[
+		"Test regex query param URL with an encoded +",
+		{
+			"source": {
+				"url": "/app/?param=2r8b%2B6h"
+			},
+			"target": {
+				"location": "/plain-redirect?param=2r8b%2B6h",
+				"status": 301,
+				"agent": true
+			}
+		}
+	],
+	[
+		"Test plain 301 redirect pass encoded query to target",
+		{
+			"source": {
+				"url": "/plain-query-pass?random=2r8b%2B6h"
+			},
+			"target": {
+				"location": "/plain-redirect?random=2r8b%2B6h",
+				"status": 301,
+				"agent": true
+			}
+		}
 	]
 ]

--- a/e2e/redirects.json
+++ b/e2e/redirects.json
@@ -1,13 +1,13 @@
 {
     "plugin": {
-        "version": "4.3",
-        "date": "Sun, 09 Jun 2019 06:43:50 +0000"
+        "version": "4.6-beta-1",
+        "date": "Wed, 11 Dec 2019 09:18:36 +0000"
     },
     "groups": [
         {
             "id": 1,
             "name": "Redirections",
-            "redirects": 1,
+            "redirects": 0,
             "module_id": 1,
             "moduleName": "WordPress",
             "enabled": true
@@ -55,7 +55,7 @@
         {
             "id": 7,
             "name": "Redirections",
-            "redirects": 11,
+            "redirects": 0,
             "module_id": 1,
             "moduleName": "WordPress",
             "enabled": true
@@ -87,13 +87,125 @@
         {
             "id": 11,
             "name": "Redirections",
-            "redirects": 29,
+            "redirects": 0,
             "module_id": 1,
             "moduleName": "WordPress",
             "enabled": true
         },
         {
             "id": 12,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 13,
+            "name": "Redirections",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 14,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 15,
+            "name": "Redirections",
+            "redirects": 1,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 16,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 17,
+            "name": "Redirections",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 18,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 19,
+            "name": "Redirections",
+            "redirects": 2,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 20,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 21,
+            "name": "Redirections",
+            "redirects": 11,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 22,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 23,
+            "name": "Redirections",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 24,
+            "name": "Modified Posts",
+            "redirects": 0,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 25,
+            "name": "Redirections",
+            "redirects": 29,
+            "module_id": 1,
+            "moduleName": "WordPress",
+            "enabled": true
+        },
+        {
+            "id": 26,
             "name": "Modified Posts",
             "redirects": 0,
             "module_id": 1,
@@ -121,11 +233,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 50,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 0,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -147,11 +259,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 1,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -173,11 +285,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 2,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -199,11 +311,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 23,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 3,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -225,11 +337,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 23,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 4,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -251,11 +363,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 32,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 6,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -275,11 +387,11 @@
             "action_data": "",
             "match_type": "url",
             "title": "",
-            "hits": 32,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 7,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -301,11 +413,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 26,
             "regex": true,
-            "group_id": 11,
+            "group_id": 25,
             "position": 8,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -329,7 +441,7 @@
             "title": "",
             "hits": 0,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 9,
             "last_access": "-",
             "enabled": false
@@ -353,11 +465,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 26,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 10,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -381,7 +493,7 @@
             "title": "",
             "hits": 0,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 13,
             "last_access": "-",
             "enabled": true
@@ -405,11 +517,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 12,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -432,11 +544,11 @@
             },
             "match_type": "login",
             "title": "",
-            "hits": 7,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 13,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -460,11 +572,11 @@
             },
             "match_type": "role",
             "title": "",
-            "hits": 7,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 13,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -489,11 +601,11 @@
             },
             "match_type": "referrer",
             "title": "",
-            "hits": 14,
+            "hits": 48,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 14,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -518,11 +630,11 @@
             },
             "match_type": "agent",
             "title": "",
-            "hits": 14,
+            "hits": 48,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 15,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -548,11 +660,11 @@
             },
             "match_type": "cookie",
             "title": "",
-            "hits": 14,
+            "hits": 48,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 16,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -578,11 +690,11 @@
             },
             "match_type": "ip",
             "title": "",
-            "hits": 24,
+            "hits": 48,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 17,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -606,11 +718,11 @@
             },
             "match_type": "server",
             "title": "",
-            "hits": 7,
+            "hits": 24,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 18,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -636,11 +748,11 @@
             },
             "match_type": "header",
             "title": "",
-            "hits": 14,
+            "hits": 48,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 19,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -663,11 +775,11 @@
             },
             "match_type": "page",
             "title": "",
-            "hits": 7,
+            "hits": 22,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 20,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -689,11 +801,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 28,
+            "hits": 46,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 21,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -715,11 +827,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 22,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 22,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -741,11 +853,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 28,
+            "hits": 41,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 23,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -767,11 +879,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 28,
+            "hits": 40,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 24,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -793,11 +905,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 22,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 25,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -819,11 +931,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 26,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -845,11 +957,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 11,
+            "group_id": 25,
             "position": 27,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -871,11 +983,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": true,
-            "group_id": 11,
+            "group_id": 25,
             "position": 28,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -901,11 +1013,11 @@
             },
             "match_type": "ip",
             "title": "",
-            "hits": 6,
+            "hits": 24,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 0,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -927,11 +1039,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 1,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -953,11 +1065,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 2,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -979,11 +1091,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 3,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1005,11 +1117,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 20,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 4,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1031,11 +1143,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 13,
+            "hits": 19,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 5,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1057,11 +1169,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 13,
+            "hits": 20,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 6,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1083,11 +1195,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 24,
+            "hits": 18,
             "regex": true,
-            "group_id": 7,
+            "group_id": 21,
             "position": 7,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1109,11 +1221,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 13,
+            "hits": 18,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 8,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1135,11 +1247,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 18,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 9,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1161,11 +1273,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 14,
+            "hits": 18,
             "regex": false,
-            "group_id": 7,
+            "group_id": 21,
             "position": 10,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1187,11 +1299,11 @@
             },
             "match_type": "url",
             "title": "",
-            "hits": 1,
+            "hits": 18,
             "regex": true,
-            "group_id": 1,
+            "group_id": 15,
             "position": 0,
-            "last_access": "July 21, 2019",
+            "last_access": "December 11, 2019",
             "enabled": true
         },
         {
@@ -1215,11 +1327,37 @@
             },
             "match_type": "language",
             "title": "",
-            "hits": 2,
+            "hits": 48,
             "regex": false,
-            "group_id": 5,
+            "group_id": 19,
             "position": 11,
-            "last_access": "June 9, 2019",
+            "last_access": "December 11, 2019",
+            "enabled": true
+        },
+        {
+            "id": 43,
+            "url": "^/app/(.*)$",
+            "match_url": "regex",
+            "match_data": {
+                "source": {
+                    "flag_query": "exact",
+                    "flag_case": false,
+                    "flag_trailing": false,
+                    "flag_regex": true
+                }
+            },
+            "action_code": 301,
+            "action_type": "url",
+            "action_data": {
+                "url": "/plain-redirect$1"
+            },
+            "match_type": "url",
+            "title": "",
+            "hits": 2,
+            "regex": true,
+            "group_id": 19,
+            "position": 1,
+            "last_access": "December 11, 2019",
             "enabled": true
         }
     ]

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -302,18 +302,22 @@ class Red_Item {
 			return true;
 		}
 
-		return new WP_Error( 'redirect_create_failed', __( 'Unable to update redirect' ) );
+		return new WP_Error( 'redirect_create_failed', 'Unable to update redirect' );
 	}
 
 	/**
 	 * Determine if a requested URL matches this URL
 	 *
-	 * @param string $requested_url
+	 * @param string $requested_url The URL being requested.
 	 * @return bool true if matched, false otherwise
 	 */
-	public function is_match( $requested_url ) {
+	public function is_match( $requested_url, $original_url = false ) {
 		if ( ! $this->is_enabled() ) {
 			return false;
+		}
+
+		if ( $original_url === false ) {
+			$original_url = $requested_url;
 		}
 
 		$url = new Red_Url( $this->url );
@@ -324,8 +328,8 @@ class Red_Item {
 			// Check if our action wants a URL
 			if ( $this->action->needs_target() ) {
 				// Our action requires a target URL - get this, using our type match result
-				$target = $this->match->get_target_url( $requested_url, $url->get_url(), $this->source_flags, $target );
-				$target = Red_Url_Query::add_to_target( $target, $requested_url, $this->source_flags );
+				$target = $this->match->get_target_url( $original_url, $url->get_url(), $this->source_flags, $target );
+				$target = Red_Url_Query::add_to_target( $target, $original_url, $this->source_flags );
 				$target = apply_filters( 'redirection_url_target', $target, $this->url );
 			}
 

--- a/models/url-request.php
+++ b/models/url-request.php
@@ -1,0 +1,61 @@
+<?php
+
+class Red_Url_Request {
+	private $original_url;
+	private $decoded_url;
+
+	public function __construct( $url ) {
+		$this->original_url = apply_filters( 'redirection_url_source', $url );
+		$this->decoded_url = rawurldecode( $this->original_url );
+
+		// Replace the decoded query params with the original ones
+		$this->original_url = $this->replace_query_params( $this->original_url, $this->decoded_url );
+	}
+
+	/**
+	 * Take the decoded path part, but keep the original query params. This ensures any redirects keep the encoding.
+	 *
+	 * @param string $original_url Original unencoded URL.
+	 * @param string $decoded_url Decoded URL.
+	 * @return string
+	 */
+	private function replace_query_params( $original_url, $decoded_url ) {
+		$decoded = explode( '?', $decoded_url );
+
+		if ( count( $decoded ) > 1 ) {
+			$original = explode( '?', $original_url );
+
+			return $decoded[0] . '?' . $original[1];
+		}
+
+		return $decoded_url;
+	}
+
+	public function get_original_url() {
+		return $this->original_url;
+	}
+
+	public function get_decoded_url() {
+		return $this->decoded_url;
+	}
+
+	public function is_valid() {
+		return strlen( $this->get_decoded_url() ) > 0;
+	}
+
+	/*
+	 * Protect certain URLs from being redirected. Note we don't need to protect wp-admin, as this code doesn't run there
+	 */
+	public function is_protected_url() {
+		$rest = wp_parse_url( red_get_rest_api() );
+		$rest_api = $rest['path'] . ( isset( $rest['query'] ) ? '?' . $rest['query'] : '' );
+
+		if ( substr( $this->get_decoded_url(), 0, strlen( $rest_api ) ) === $rest_api ) {
+			// Never redirect the REST API
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/models/url.php
+++ b/models/url.php
@@ -1,9 +1,10 @@
 <?php
 
-include_once dirname( __FILE__ ) . '/url-query.php';
-include_once dirname( __FILE__ ) . '/url-path.php';
-include_once dirname( __FILE__ ) . '/url-match.php';
-include_once dirname( __FILE__ ) . '/url-flags.php';
+require_once __DIR__ . '/url-query.php';
+require_once __DIR__ . '/url-path.php';
+require_once __DIR__ . '/url-match.php';
+require_once __DIR__ . '/url-flags.php';
+require_once __DIR__ . '/url-request.php';
 
 class Red_Url {
 	private $url;

--- a/tests/models/test-url-request.php
+++ b/tests/models/test-url-request.php
@@ -1,0 +1,57 @@
+<?php
+
+class UrlRequestTest extends WP_UnitTestCase {
+	public function testNoUrl() {
+		$request = new Red_Url_Request( '' );
+
+		$this->assertFalse( $request->is_valid() );
+		$this->assertEquals( '', $request->get_decoded_url() );
+		$this->assertEquals( '', $request->get_original_url() );
+	}
+
+	public function testPlainUrl() {
+		$url = '/thing';
+		$request = new Red_Url_Request( $url );
+
+		$this->assertTrue( $request->is_valid() );
+		$this->assertEquals( $url, $request->get_decoded_url() );
+		$this->assertEquals( $url, $request->get_original_url() );
+	}
+
+	public function testPlainQueryUrl() {
+		$url = '/thing?param=1';
+		$request = new Red_Url_Request( $url );
+
+		$this->assertTrue( $request->is_valid() );
+		$this->assertEquals( $url, $request->get_decoded_url() );
+		$this->assertEquals( $url, $request->get_original_url() );
+	}
+
+	public function testEncodedPathUrl() {
+		$url = '/th%20ing?param=1';
+		$expected = '/th ing?param=1';
+		$request = new Red_Url_Request( $url );
+
+		$this->assertTrue( $request->is_valid() );
+		$this->assertEquals( $expected, $request->get_decoded_url() );
+		$this->assertEquals( $expected, $request->get_original_url() );
+	}
+
+	public function testEncodedQueryUrl() {
+		$url = '/thing?param=%2B';
+		$request = new Red_Url_Request( $url );
+
+		$this->assertTrue( $request->is_valid() );
+		$this->assertEquals( '/thing?param=+', $request->get_decoded_url() );
+		$this->assertEquals( $url, $request->get_original_url() );
+	}
+
+	public function testEmptyQueryUrl() {
+		$url = '/thing?';
+		$request = new Red_Url_Request( $url );
+
+		$this->assertTrue( $request->is_valid() );
+		$this->assertEquals( $url, $request->get_decoded_url() );
+		$this->assertEquals( $url, $request->get_original_url() );
+	}
+}


### PR DESCRIPTION
When copying parameters from the source to target it would copy the decoded values. This fixes it so that we copy the original (encoded) parameters, following the behaviour of Nginx

Fixes #2056 