### PR TITLE
Prevent not finding redirection in active plugins

### DIFF
--- a/api/api-plugin.php
+++ b/api/api-plugin.php
@@ -88,8 +88,11 @@ class Redirection_Api_Plugin extends Redirection_Api_Route {
 		$plugin->plugin_uninstall();
 
 		$current = get_option( 'active_plugins' );
-		array_splice( $current, array_search( basename( dirname( REDIRECTION_FILE ) ) . '/' . basename( REDIRECTION_FILE ), $current ), 1 );
-		update_option( 'active_plugins', $current );
+		$plugin_position = array_search( basename( dirname( REDIRECTION_FILE ) ) . '/' . basename( REDIRECTION_FILE ), $current );
+		if ( false !== $plugin_position ) {
+			array_splice( $current, $plugin_position, 1 );
+			update_option( 'active_plugins', $current );
+		}
 
 		return array( 'location' => admin_url() . 'plugins.php' );
 	}


### PR DESCRIPTION
Hello @johngodley and thanks for this awesome plugin.

We are managing a WordPress Multisite for our clients and found out that your delete plugin logic was disabling random plugins. For instance, when the plugin is active for all the sites (network active), is not stored in the active_plugins option site.

The cause of the issue was that if array_search function does not find the string in the array returns a false and that false value is treated as a 0 in the array_splice, removing the first element of the array.

Thanks!