### PR TITLE
Fix Random_Action

### DIFF
--- a/actions/random.php
+++ b/actions/random.php
@@ -8,7 +8,7 @@ class Random_Action extends Url_Action {
 		global $wpdb;
 
 		$id = $wpdb->get_var( "SELECT ID FROM {$wpdb->prefix}posts WHERE post_status='publish' AND post_password='' AND post_type='post' ORDER BY RAND() LIMIT 0,1" );
-		return str_replace( get_bloginfo( 'url' ), '', get_permalink( $id ) );
+		return get_permalink( $id );
 	}
 
 	public function process_after( $code, $target ) {
@@ -16,6 +16,6 @@ class Random_Action extends Url_Action {
 	}
 
 	public function needs_target() {
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
This commit fixes two issues below:
+ The option `Redirect to random post` doesn't need a target url on the front panel, but the method `needs_target` of `Random_Action` returns `true` so that the random redirection never works.
+ The previous code doesn't work correctly if the blogurl is not root such as `http://example.com/wordpresss`. It will redirect to `http://example.com/archives/123`, but the expected url is `http://example.com/wordpresss/archives/123`.