### PR TITLE
Copy URL fragment to the end of the URL

### DIFF
--- a/models/url-query.php
+++ b/models/url-query.php
@@ -79,7 +79,9 @@ class Red_Url_Query {
 			$query = preg_replace( '@%5B\d*%5D@', '[]', $query );  // Make these look like []
 
 			if ( $query ) {
-				return $target_url . ( strpos( $target_url, '?' ) === false ? '?' : '&' ) . $query;
+				$target_fragment = parse_url( $target_url, PHP_URL_FRAGMENT );
+				$target_url = str_replace( '#' . $target_fragment, '', $target_url );
+				return $target_url . ( strpos( $target_url, '?' ) === false ? '?' : '&' ) . $query . ( $target_fragment ? '#'. $target_fragment : '' );				
 			}
 		}
 


### PR DESCRIPTION
When a user chooses to pass URL query parameters to the target URL, parameters are appended at the end of the target URL, ie:

source: https://somedomain.com?foo=bar
target: https://otherdomain.com#header
redirect: https://otherdomain.com#header?foo=bar

On the resulting URL query parameters are incorrectly detected as part of the fragment.

The proposed change fixes this by stripping the URL fragment from the target URL and then appending it to the end, in conformance with [RFC 3986](https://tools.ietf.org/html/rfc3986#section-4.1)