### PR TITLE
Improve DB query

### DIFF
--- a/client/component/redirect-edit/constants.js
+++ b/client/component/redirect-edit/constants.js
@@ -199,8 +199,12 @@ export const FLAG_CASE = 2;
 
 export const getSourceQuery = () => [
 	{
+		value: 'exactorder',
+		label: __( 'Exact match' ),
+	},
+	{
 		value: 'exact',
-		label: __( 'Exact match all parameters in any order' ),
+		label: __( 'Exact match in any order' ),
 	},
 	{
 		value: 'ignore',

--- a/client/component/redirect-edit/index.js
+++ b/client/component/redirect-edit/index.js
@@ -292,7 +292,7 @@ class EditRedirect extends React.Component {
 		return (
 			<>
 				<RedirectSourceUrl url={ url } flags={ this.state } defaultFlags={ flags } autoFocus={ autoFocus } onFlagChange={ this.onFlagChange } onChange={ this.onChange } />
-				<RedirectSourceQuery query={ flag_query } regex={ flag_regex } onChange={ this.onChange } />
+				<RedirectSourceQuery query={ flag_query } regex={ flag_regex } onChange={ this.onChange } url={ url } />
 				{ advanced &&
 
 					<>

--- a/client/component/redirect-edit/source-query.js
+++ b/client/component/redirect-edit/source-query.js
@@ -13,14 +13,17 @@ import { Select } from 'wp-plugin-components';
 import TableRow from './table-row';
 import { getSourceQuery } from './constants';
 
-const RedirectSourceQuery = ( { query, regex, onChange } ) => {
+const RedirectSourceQuery = ( { query, regex, onChange, url } ) => {
 	if ( regex ) {
 		return null;
 	}
 
+	const items =
+		url.indexOf( '?' ) === -1 ? getSourceQuery().filter( ( item ) => item.value !== 'exactorder' ) : getSourceQuery();
+
 	return (
 		<TableRow title={ __( 'Query Parameters' ) } className="redirect-edit__sourcequery">
-			<Select name="flag_query" items={ getSourceQuery() } value={ query } onChange={ onChange } />
+			<Select name="flag_query" items={ items } value={ query } onChange={ onChange } />
 		</TableRow>
 	);
 };

--- a/client/page/options/options-form.js
+++ b/client/page/options/options-form.js
@@ -40,7 +40,7 @@ export const restApi = () => [
 	{ value: 3, label: __( 'Relative REST API' ) },
 ];
 export const queryMatch = () => [
-	{ value: 'exact', label: __( 'Exact match' ) },
+	{ value: 'exact', label: __( 'Exact match in any order' ) },
 	{ value: 'ignore', label: __( 'Ignore all query parameters' ) },
 	{ value: 'pass', label: __( 'Ignore and pass all query parameters' ) },
 ];

--- a/database/database-status.php
+++ b/database/database-status.php
@@ -191,6 +191,7 @@ class Red_Database_Status {
 	 * Move current stage on to the next
 	 */
 	public function set_next_stage() {
+		$this->debug = [];
 		$stage = $this->get_current_stage();
 
 		if ( $stage ) {

--- a/database/schema/400.php
+++ b/database/schema/400.php
@@ -57,10 +57,14 @@ class Red_Database_400 extends Red_Database_Upgrader {
 		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url='regex' WHERE regex=1" );
 
 		// Remove query part from all URLs and lowercase
-		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=SUBSTRING_INDEX(LOWER(url), '?', 1) WHERE regex=0" );
+		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=LOWER(url) WHERE regex=0" );
+
+		// Set exact match if query param present
+		$this->do_query( $wpdb, $wpdb->prepare( "UPDATE `{$wpdb->prefix}redirection_items` SET match_data=%s WHERE regex=0 AND match_url LIKE '%?%'", '{"source":{"flag_query":"exactorder"}}' ) );
 
 		// Trim the last / from a URL
 		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=LEFT(match_url,LENGTH(match_url)-1) WHERE regex=0 AND match_url != '/' AND RIGHT(match_url, 1) = '/'" );
+		$this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url=REPLACE(match_url, '/?', '?') WHERE regex=0" );
 
 		// Any URL that is now empty becomes /
 		return $this->do_query( $wpdb, "UPDATE `{$wpdb->prefix}redirection_items` SET match_url='/' WHERE match_url=''" );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
             WORDPRESS_DB_USER: wordpress
             WORDPRESS_DB_PASSWORD: wordpress
             WORDPRESS_DB_NAME: wordpress
-            VIRTUAL_HOST: redirectione2e.local
+            VIRTUAL_HOST: redirection-e2e.local
         volumes:
             - wordpress:/var/www/html
             - ./:/var/www/html/wp-content/plugins/redirection

--- a/e2e/__tests__/url.json
+++ b/e2e/__tests__/url.json
@@ -425,5 +425,18 @@
 				"agent": true
 			}
 		}
+	],
+	[
+		"Test an exact order redirect",
+		{
+			"source": {
+				"url": "/exact-order?thing=1"
+			},
+			"target": {
+				"location": "/plain-redirect",
+				"status": 301,
+				"agent": true
+			}
+		}
 	]
 ]

--- a/e2e/redirects.json
+++ b/e2e/redirects.json
@@ -1,1364 +1,1402 @@
 {
-    "plugin": {
-        "version": "4.6-beta-1",
-        "date": "Wed, 11 Dec 2019 09:18:36 +0000"
-    },
-    "groups": [
-        {
-            "id": 1,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 2,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 3,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 4,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 5,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 6,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 7,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 8,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 9,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 10,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 11,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 12,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 13,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 14,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 15,
-            "name": "Redirections",
-            "redirects": 1,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 16,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 17,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 18,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 19,
-            "name": "Redirections",
-            "redirects": 2,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 20,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 21,
-            "name": "Redirections",
-            "redirects": 11,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 22,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 23,
-            "name": "Redirections",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 24,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 25,
-            "name": "Redirections",
-            "redirects": 29,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        },
-        {
-            "id": 26,
-            "name": "Modified Posts",
-            "redirects": 0,
-            "module_id": 1,
-            "moduleName": "WordPress",
-            "enabled": true
-        }
-    ],
-    "redirects": [
-        {
-            "id": 1,
-            "url": "/plain301",
-            "match_url": "/plain301",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 50,
-            "regex": false,
-            "group_id": 25,
-            "position": 0,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 2,
-            "url": "/plain302",
-            "match_url": "/plain302",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 302,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 1,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 3,
-            "url": "/plain303",
-            "match_url": "/plain303",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 303,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 2,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 4,
-            "url": "/plain307",
-            "match_url": "/plain307",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 307,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 23,
-            "regex": false,
-            "group_id": 25,
-            "position": 3,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 5,
-            "url": "/plain308",
-            "match_url": "/plain308",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 308,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 23,
-            "regex": false,
-            "group_id": 25,
-            "position": 4,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 6,
-            "url": "/plain-pass",
-            "match_url": "/plain-pass",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 0,
-            "action_type": "pass",
-            "action_data": {
-                "url": "/"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 6,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 7,
-            "url": "/plain-ignore",
-            "match_url": "/plain-ignore",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 0,
-            "action_type": "nothing",
-            "action_data": "",
-            "match_type": "url",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 7,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 8,
-            "url": "^/plain-regex/(.*)",
-            "match_url": "regex",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": true
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect/$1"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 26,
-            "regex": true,
-            "group_id": 25,
-            "position": 8,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 9,
-            "url": "/plain-redirect-disabled",
-            "match_url": "/plain-redirect-disabled",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 0,
-            "regex": false,
-            "group_id": 25,
-            "position": 9,
-            "last_access": "-",
-            "enabled": false
-        },
-        {
-            "id": 10,
-            "url": "/plain-redirect-absolute",
-            "match_url": "/plain-redirect-absolute",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "http://wordpress.org"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 26,
-            "regex": false,
-            "group_id": 25,
-            "position": 10,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 11,
-            "url": "/plain-position",
-            "match_url": "/plain-position",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect1"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 0,
-            "regex": false,
-            "group_id": 25,
-            "position": 13,
-            "last_access": "-",
-            "enabled": true
-        },
-        {
-            "id": 12,
-            "url": "/plain-position",
-            "match_url": "/plain-position",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect2"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 12,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 13,
-            "url": "/login",
-            "match_url": "/login",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "logged_in": "/login/match",
-                "logged_out": "/login/notmatch"
-            },
-            "match_type": "login",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 13,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 14,
-            "url": "/capability",
-            "match_url": "/capability",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "role": "manage_links",
-                "url_from": "/capability/match",
-                "url_notfrom": "/capability/notmatch"
-            },
-            "match_type": "role",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 13,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 15,
-            "url": "/referrer",
-            "match_url": "/referrer",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "regex": false,
-                "referrer": "test referrer",
-                "url_from": "/referrer/match",
-                "url_notfrom": "/referrer/notmatch"
-            },
-            "match_type": "referrer",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 25,
-            "position": 14,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 16,
-            "url": "/useragent",
-            "match_url": "/useragent",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "regex": false,
-                "agent": "test agent",
-                "url_from": "/useragent/match",
-                "url_notfrom": "/useragent/notmatch"
-            },
-            "match_type": "agent",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 25,
-            "position": 15,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 17,
-            "url": "/cookie",
-            "match_url": "/cookie",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "regex": false,
-                "name": "cookie",
-                "value": "cookievalue",
-                "url_from": "/cookie/match",
-                "url_notfrom": "/cookie/notmatch"
-            },
-            "match_type": "cookie",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 25,
-            "position": 16,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 18,
-            "url": "/ip",
-            "match_url": "/ip",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "ip": [
-                    "192.168.1.66"
-                ],
-                "url_from": "/ip/match",
-                "url_notfrom": "/ip/notmatch"
-            },
-            "match_type": "ip",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 25,
-            "position": 17,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 19,
-            "url": "/server",
-            "match_url": "/server",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "server": "http://test.com",
-                "url_from": "/server/match",
-                "url_notfrom": "/server/notmatch"
-            },
-            "match_type": "server",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 25,
-            "position": 18,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 20,
-            "url": "/http",
-            "match_url": "/http",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "regex": false,
-                "name": "testheader",
-                "value": "testvalue",
-                "url_from": "/http/match",
-                "url_notfrom": "/http/notmatch"
-            },
-            "match_type": "header",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 25,
-            "position": 19,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 21,
-            "url": "/pagetype",
-            "match_url": "/pagetype",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "page": "404",
-                "url": "/pagetype-redirect"
-            },
-            "match_type": "page",
-            "title": "",
-            "hits": 22,
-            "regex": false,
-            "group_id": 25,
-            "position": 20,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 22,
-            "url": "/plain-trailing-slash",
-            "match_url": "/plain-trailing-slash",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": true,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 46,
-            "regex": false,
-            "group_id": 25,
-            "position": 21,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 23,
-            "url": "/plain-trailing-case",
-            "match_url": "/plain-trailing-case",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": true,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 22,
-            "regex": false,
-            "group_id": 25,
-            "position": 22,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 24,
-            "url": "/plain-query-ignore",
-            "match_url": "/plain-query-ignore",
-            "match_data": {
-                "source": {
-                    "flag_query": "ignore",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 41,
-            "regex": false,
-            "group_id": 25,
-            "position": 23,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 25,
-            "url": "/plain-query-exact?param1=1&param2=2",
-            "match_url": "/plain-query-exact",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 40,
-            "regex": false,
-            "group_id": 25,
-            "position": 24,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 26,
-            "url": "/plain-query-pass",
-            "match_url": "/plain-query-pass",
-            "match_data": {
-                "source": {
-                    "flag_query": "pass",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 22,
-            "regex": false,
-            "group_id": 25,
-            "position": 25,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 27,
-            "url": "/plain-query-pass-existing",
-            "match_url": "/plain-query-pass-existing",
-            "match_data": {
-                "source": {
-                    "flag_query": "pass",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect?random=yes"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 25,
-            "position": 26,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 28,
-            "url": "/plain-query-all",
-            "match_url": "/plain-query-all",
-            "match_data": {
-                "source": {
-                    "flag_query": "ignore",
-                    "flag_case": true,
-                    "flag_trailing": true,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 25,
-            "position": 27,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 29,
-            "url": "^/plain-case-regex/(.*)",
-            "match_url": "regex",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": true,
-                    "flag_trailing": false,
-                    "flag_regex": true
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect/$1"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": true,
-            "group_id": 25,
-            "position": 28,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 30,
-            "url": "/ip/403",
-            "match_url": "/ip/403",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 403,
-            "action_type": "error",
-            "action_data": {
-                "ip": [
-                    "192.168.1.66"
-                ],
-                "url_from": "",
-                "url_notfrom": ""
-            },
-            "match_type": "ip",
-            "title": "",
-            "hits": 24,
-            "regex": false,
-            "group_id": 21,
-            "position": 0,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 31,
-            "url": "//",
-            "match_url": "/",
-            "match_data": {
-                "source": {
-                    "flag_query": "ignore",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 21,
-            "position": 1,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 32,
-            "url": "//thing/here",
-            "match_url": "//thing/here",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 21,
-            "position": 2,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 33,
-            "url": "/plain-array/?arr[]=1&arr[]=2&arr[]=3",
-            "match_url": "/plain-array",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 21,
-            "position": 3,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 34,
-            "url": "/plain-array-pass/?arr[]=3&arr[]=2&arr[]=1",
-            "match_url": "/plain-array-pass",
-            "match_data": {
-                "source": {
-                    "flag_query": "pass",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 21,
-            "position": 4,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 35,
-            "url": "/hello-world2:\u4e2d\u56fd/",
-            "match_url": "/hello-world2:%e4%b8%ad%e5%9b%bd",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 19,
-            "regex": false,
-            "group_id": 21,
-            "position": 5,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 36,
-            "url": "/gardens/Journey's-End_p.html",
-            "match_url": "/gardens/journey%27s-end_p.html",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": true,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 20,
-            "regex": false,
-            "group_id": 21,
-            "position": 6,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 37,
-            "url": "^/\u4e2d\u56fd(.*)",
-            "match_url": "regex",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": true
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 18,
-            "regex": true,
-            "group_id": 21,
-            "position": 7,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 38,
-            "url": "/encoded-\u4e2d\u56fdsomething",
-            "match_url": "/encoded-%e4%b8%ad%e5%9b%bdsomething",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 18,
-            "regex": false,
-            "group_id": 21,
-            "position": 8,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 39,
-            "url": "/plain301-invalid?=1",
-            "match_url": "/plain301-invalid",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 18,
-            "regex": false,
-            "group_id": 21,
-            "position": 9,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 40,
-            "url": "/plain301-query-case?cats=1",
-            "match_url": "/plain301-query-case",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": true,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 18,
-            "regex": false,
-            "group_id": 21,
-            "position": 10,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 41,
-            "url": "^/hello\\+world",
-            "match_url": "regex",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": true
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 18,
-            "regex": true,
-            "group_id": 15,
-            "position": 0,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 42,
-            "url": "/language",
-            "match_url": "/language",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": false
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "language": "de",
-                "url_from": "/language/match",
-                "url_notfrom": "/language/notmatch"
-            },
-            "match_type": "language",
-            "title": "",
-            "hits": 48,
-            "regex": false,
-            "group_id": 19,
-            "position": 11,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        },
-        {
-            "id": 43,
-            "url": "^/app/(.*)$",
-            "match_url": "regex",
-            "match_data": {
-                "source": {
-                    "flag_query": "exact",
-                    "flag_case": false,
-                    "flag_trailing": false,
-                    "flag_regex": true
-                }
-            },
-            "action_code": 301,
-            "action_type": "url",
-            "action_data": {
-                "url": "/plain-redirect$1"
-            },
-            "match_type": "url",
-            "title": "",
-            "hits": 2,
-            "regex": true,
-            "group_id": 19,
-            "position": 1,
-            "last_access": "December 11, 2019",
-            "enabled": true
-        }
-    ]
+	"plugin": {
+		"version": "4.9.1",
+		"date": "Thu, 29 Oct 2020 14:19:57 +0000"
+	},
+	"groups": [
+		{
+			"id": 1,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 2,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 3,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 4,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 5,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 6,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 7,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 8,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 9,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 10,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 11,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 12,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 13,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 14,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 15,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 16,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 17,
+			"name": "Redirections",
+			"redirects": 1,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 18,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 19,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 20,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 21,
+			"name": "Redirections",
+			"redirects": 3,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 22,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 23,
+			"name": "Redirections",
+			"redirects": 11,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 24,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 25,
+			"name": "Redirections",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 26,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 27,
+			"name": "Redirections",
+			"redirects": 29,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		},
+		{
+			"id": 28,
+			"name": "Modified Posts",
+			"redirects": 0,
+			"module_id": 1,
+			"moduleName": "WordPress",
+			"enabled": true
+		}
+	],
+	"redirects": [
+		{
+			"id": 1,
+			"url": "/plain301",
+			"match_url": "/plain301",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 18,
+			"regex": false,
+			"group_id": 27,
+			"position": 0,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 2,
+			"url": "/plain302",
+			"match_url": "/plain302",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 302,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 1,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 3,
+			"url": "/plain303",
+			"match_url": "/plain303",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 303,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 2,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 4,
+			"url": "/plain307",
+			"match_url": "/plain307",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 307,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 3,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 5,
+			"url": "/plain308",
+			"match_url": "/plain308",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 308,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 4,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 6,
+			"url": "/plain-pass",
+			"match_url": "/plain-pass",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 0,
+			"action_type": "pass",
+			"action_data": {
+				"url": "/"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 6,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 7,
+			"url": "/plain-ignore",
+			"match_url": "/plain-ignore",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 0,
+			"action_type": "nothing",
+			"action_data": "",
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 7,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 8,
+			"url": "^/plain-regex/(.*)",
+			"match_url": "regex",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": true
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect/$1"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": true,
+			"group_id": 27,
+			"position": 8,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 9,
+			"url": "/plain-redirect-disabled",
+			"match_url": "/plain-redirect-disabled",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 0,
+			"regex": false,
+			"group_id": 27,
+			"position": 9,
+			"last_access": "-",
+			"enabled": false
+		},
+		{
+			"id": 10,
+			"url": "/plain-redirect-absolute",
+			"match_url": "/plain-redirect-absolute",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "http://wordpress.org"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 10,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 11,
+			"url": "/plain-position",
+			"match_url": "/plain-position",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect1"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 0,
+			"regex": false,
+			"group_id": 27,
+			"position": 13,
+			"last_access": "-",
+			"enabled": true
+		},
+		{
+			"id": 12,
+			"url": "/plain-position",
+			"match_url": "/plain-position",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect2"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 12,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 13,
+			"url": "/login",
+			"match_url": "/login",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"logged_in": "/login/match",
+				"logged_out": "/login/notmatch"
+			},
+			"match_type": "login",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 13,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 14,
+			"url": "/capability",
+			"match_url": "/capability",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"role": "manage_links",
+				"url_from": "/capability/match",
+				"url_notfrom": "/capability/notmatch"
+			},
+			"match_type": "role",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 13,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 15,
+			"url": "/referrer",
+			"match_url": "/referrer",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"regex": false,
+				"referrer": "test referrer",
+				"url_from": "/referrer/match",
+				"url_notfrom": "/referrer/notmatch"
+			},
+			"match_type": "referrer",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 14,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 16,
+			"url": "/useragent",
+			"match_url": "/useragent",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"regex": false,
+				"agent": "test agent",
+				"url_from": "/useragent/match",
+				"url_notfrom": "/useragent/notmatch"
+			},
+			"match_type": "agent",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 15,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 17,
+			"url": "/cookie",
+			"match_url": "/cookie",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"regex": false,
+				"name": "cookie",
+				"value": "cookievalue",
+				"url_from": "/cookie/match",
+				"url_notfrom": "/cookie/notmatch"
+			},
+			"match_type": "cookie",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 16,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 18,
+			"url": "/ip",
+			"match_url": "/ip",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"ip": [ "192.168.1.66" ],
+				"url_from": "/ip/match",
+				"url_notfrom": "/ip/notmatch"
+			},
+			"match_type": "ip",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 17,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 19,
+			"url": "/server",
+			"match_url": "/server",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"server": "http://test.com",
+				"url_from": "/server/match",
+				"url_notfrom": "/server/notmatch"
+			},
+			"match_type": "server",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 18,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 20,
+			"url": "/http",
+			"match_url": "/http",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"regex": false,
+				"name": "testheader",
+				"value": "testvalue",
+				"url_from": "/http/match",
+				"url_notfrom": "/http/notmatch"
+			},
+			"match_type": "header",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 19,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 21,
+			"url": "/pagetype",
+			"match_url": "/pagetype",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"page": "404",
+				"url": "/pagetype-redirect"
+			},
+			"match_type": "page",
+			"title": "",
+			"hits": 5,
+			"regex": false,
+			"group_id": 27,
+			"position": 20,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 22,
+			"url": "/plain-trailing-slash",
+			"match_url": "/plain-trailing-slash",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": true,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 21,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 23,
+			"url": "/plain-trailing-case",
+			"match_url": "/plain-trailing-case",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": true,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 22,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 24,
+			"url": "/plain-query-ignore",
+			"match_url": "/plain-query-ignore",
+			"match_data": {
+				"source": {
+					"flag_query": "ignore",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 23,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 25,
+			"url": "/plain-query-exact?param1=1&param2=2",
+			"match_url": "/plain-query-exact",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 24,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 26,
+			"url": "/plain-query-pass",
+			"match_url": "/plain-query-pass",
+			"match_data": {
+				"source": {
+					"flag_query": "pass",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 27,
+			"position": 25,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 27,
+			"url": "/plain-query-pass-existing",
+			"match_url": "/plain-query-pass-existing",
+			"match_data": {
+				"source": {
+					"flag_query": "pass",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect?random=yes"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 26,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 28,
+			"url": "/plain-query-all",
+			"match_url": "/plain-query-all",
+			"match_data": {
+				"source": {
+					"flag_query": "ignore",
+					"flag_case": true,
+					"flag_trailing": true,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 27,
+			"position": 27,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 29,
+			"url": "^/plain-case-regex/(.*)",
+			"match_url": "regex",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": true,
+					"flag_trailing": false,
+					"flag_regex": true
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect/$1"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": true,
+			"group_id": 27,
+			"position": 28,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 30,
+			"url": "/ip/403",
+			"match_url": "/ip/403",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 403,
+			"action_type": "error",
+			"action_data": {
+				"ip": [ "192.168.1.66" ],
+				"url_from": "",
+				"url_notfrom": ""
+			},
+			"match_type": "ip",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 0,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 31,
+			"url": "//",
+			"match_url": "/",
+			"match_data": {
+				"source": {
+					"flag_query": "ignore",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 1,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 32,
+			"url": "//thing/here",
+			"match_url": "//thing/here",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 2,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 33,
+			"url": "/plain-array/?arr[]=1&arr[]=2&arr[]=3",
+			"match_url": "/plain-array",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 3,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 34,
+			"url": "/plain-array-pass/?arr[]=3&arr[]=2&arr[]=1",
+			"match_url": "/plain-array-pass",
+			"match_data": {
+				"source": {
+					"flag_query": "pass",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 4,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 35,
+			"url": "/hello-world2:\u4e2d\u56fd/",
+			"match_url": "/hello-world2:%e4%b8%ad%e5%9b%bd",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 5,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 36,
+			"url": "/gardens/Journey's-End_p.html",
+			"match_url": "/gardens/journey%27s-end_p.html",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": true,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 6,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 37,
+			"url": "^/\u4e2d\u56fd(.*)",
+			"match_url": "regex",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": true
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": true,
+			"group_id": 23,
+			"position": 7,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 38,
+			"url": "/encoded-\u4e2d\u56fdsomething",
+			"match_url": "/encoded-%e4%b8%ad%e5%9b%bdsomething",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 8,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 39,
+			"url": "/plain301-invalid?=1",
+			"match_url": "/plain301-invalid",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 9,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 40,
+			"url": "/plain301-query-case?cats=1",
+			"match_url": "/plain301-query-case",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": true,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": false,
+			"group_id": 23,
+			"position": 10,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 41,
+			"url": "^/hello\\+world",
+			"match_url": "regex",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": true
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": true,
+			"group_id": 17,
+			"position": 0,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 42,
+			"url": "/language",
+			"match_url": "/language",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"language": "de",
+				"url_from": "/language/match",
+				"url_notfrom": "/language/notmatch"
+			},
+			"match_type": "language",
+			"title": "",
+			"hits": 12,
+			"regex": false,
+			"group_id": 21,
+			"position": 11,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 43,
+			"url": "^/app/(.*)$",
+			"match_url": "regex",
+			"match_data": {
+				"source": {
+					"flag_query": "exact",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": true
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect$1"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 6,
+			"regex": true,
+			"group_id": 21,
+			"position": 1,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		},
+		{
+			"id": 44,
+			"url": "/exact-order?thing=1",
+			"match_url": "/exact-order?thing=1",
+			"match_data": {
+				"source": {
+					"flag_query": "exactorder",
+					"flag_case": false,
+					"flag_trailing": false,
+					"flag_regex": false
+				}
+			},
+			"action_code": 301,
+			"action_type": "url",
+			"action_data": {
+				"url": "/plain-redirect"
+			},
+			"match_type": "url",
+			"title": "",
+			"hits": 1,
+			"regex": false,
+			"group_id": 21,
+			"position": 2,
+			"last_access": "October 29, 2020",
+			"enabled": true
+		}
+	]
 }

--- a/models/action.php
+++ b/models/action.php
@@ -1,9 +1,28 @@
 <?php
 
+/**
+ * A redirect action - what happens after a URL is matched.
+ */
 abstract class Red_Action {
+	/**
+	 * The action code (i.e. HTTP code)
+	 *
+	 * @var integer
+	 */
 	protected $code;
+
+	/**
+	 * The action type
+	 *
+	 * @var string
+	 */
 	protected $type;
 
+	/**
+	 * Constructor
+	 *
+	 * @param array $values Values.
+	 */
 	public function __construct( $values ) {
 		if ( is_array( $values ) ) {
 			foreach ( $values as $key => $value ) {
@@ -12,6 +31,13 @@ abstract class Red_Action {
 		}
 	}
 
+	/**
+	 * Create an action object
+	 *
+	 * @param string $name Action type.
+	 * @param string $code Action code.
+	 * @return Red_Action|false
+	 */
 	public static function create( $name, $code ) {
 		$avail = self::available();
 
@@ -28,6 +54,11 @@ abstract class Red_Action {
 		return false;
 	}
 
+	/**
+	 * Get list of available actions
+	 *
+	 * @return array
+	 */
 	public static function available() {
 		return array(
 			'url'     => array( 'url.php', 'Url_Action' ),
@@ -38,21 +69,50 @@ abstract class Red_Action {
 		);
 	}
 
+	/**
+	 * Perform any processing before the action
+	 *
+	 * @param integer $code Target HTTP code.
+	 * @param string  $target Target URL.
+	 * @return string
+	 */
 	public function process_before( $code, $target ) {
 		return $target;
 	}
 
+	/**
+	 * Perform any processing after the action
+	 *
+	 * @param integer $code Target HTTP code.
+	 * @param string  $target Target URL.
+	 * @return boolean
+	 */
 	public function process_after( $code, $target ) {
 		return true;
 	}
 
+	/**
+	 * Get the action code
+	 *
+	 * @return integer
+	 */
 	public function get_code() {
 		return $this->code;
 	}
 
+	/**
+	 * Get action type
+	 *
+	 * @return string
+	 */
 	public function get_type() {
 		return $this->type;
 	}
 
+	/**
+	 * Does this action need a target?
+	 *
+	 * @return boolean
+	 */
 	abstract public function needs_target();
 }

--- a/models/match.php
+++ b/models/match.php
@@ -1,20 +1,61 @@
 <?php
 
+/**
+ * Matches a URL and some other condition
+ */
 abstract class Red_Match {
+	/**
+	 * Match type
+	 *
+	 * @var string
+	 */
 	protected $type;
 
+	/**
+	 * Constructor
+	 *
+	 * @param array|string $values Initial values.
+	 */
 	public function __construct( $values = '' ) {
 		if ( $values ) {
 			$this->load( $values );
 		}
 	}
 
+	/**
+	 * Get match type
+	 *
+	 * @return string
+	 */
 	public function get_type() {
 		return $this->type;
 	}
 
+	/**
+	 * Save the match
+	 *
+	 * @param array   $details Details to save.
+	 * @param boolean $no_target_url The URL when no target.
+	 * @return array
+	 */
 	abstract public function save( array $details, $no_target_url = false );
+
+	/**
+	 * Get the match name
+	 *
+	 * @return String
+	 */
 	abstract public function name();
+
+	/**
+	 * Get the target URL
+	 *
+	 * @param String           $url URL of this redirect.
+	 * @param String           $matched_url URL that was matched from the client.
+	 * @param Red_Source_Flags $flag Flags.
+	 * @param boolean          $is_matched Is this matched.
+	 * @return String
+	 */
 	abstract public function get_target_url( $url, $matched_url, Red_Source_Flags $flag, $is_matched );
 	abstract public function is_match( $url );
 	abstract public function get_data();
@@ -30,12 +71,28 @@ abstract class Red_Match {
 		return $url;
 	}
 
+	/**
+	 * Get a regular expression target URL
+	 *
+	 * @param [type] $source_url
+	 * @param [type] $target_url
+	 * @param [type] $requested_url
+	 * @param Red_Source_Flags $flags
+	 * @return void
+	 */
 	protected function get_target_regex_url( $source_url, $target_url, $requested_url, Red_Source_Flags $flags ) {
 		$regex = new Red_Regex( $source_url, $flags->is_ignore_case() );
 
 		return $regex->replace( $target_url, $requested_url );
 	}
 
+	/**
+	 * Create a Red_Match object, given a type
+	 *
+	 * @param string $name Match type.
+	 * @param string $data Match data.
+	 * @return Red_Match|false
+	 */
 	public static function create( $name, $data = '' ) {
 		$avail = self::available();
 		if ( isset( $avail[ strtolower( $name ) ] ) ) {
@@ -53,6 +110,11 @@ abstract class Red_Match {
 		return false;
 	}
 
+	/**
+	 * Get all Red_Match objects
+	 *
+	 * @return Red_Match[]
+	 */
 	public static function all() {
 		$data = array();
 
@@ -65,6 +127,11 @@ abstract class Red_Match {
 		return $data;
 	}
 
+	/**
+	 * Get list of available matches
+	 *
+	 * @return array
+	 */
 	public static function available() {
 		return array(
 			'url'      => 'url.php',
@@ -83,9 +150,25 @@ abstract class Red_Match {
 	}
 }
 
+/**
+ * Trait to add redirect matching
+ */
 trait FromUrl_Match {
+	/**
+	 * URL to match against
+	 *
+	 * @var string
+	 */
 	public $url;
 
+	/**
+	 * Save match data
+	 *
+	 * @param array  $details Match data.
+	 * @param string $no_target_url
+	 * @param array  $data
+	 * @return array
+	 */
 	private function save_data( array $details, $no_target_url, array $data ) {
 		if ( $no_target_url === false ) {
 			return array_merge( array(
@@ -96,6 +179,15 @@ trait FromUrl_Match {
 		return $data;
 	}
 
+	/**
+	 * Get target URL for this match, depending on whether we match or not
+	 *
+	 * @param string           $requested_url Request URL.
+	 * @param string           $source_url Redirect source URL.
+	 * @param Red_Source_Flags $flags Redirect flags.
+	 * @param [type] $matched
+	 * @return string
+	 */
 	public function get_target_url( $requested_url, $source_url, Red_Source_Flags $flags, $matched ) {
 		$target = $this->get_matched_target( $matched );
 
@@ -183,6 +275,11 @@ trait FromNotFrom_Match {
 		return $values;
 	}
 
+	/**
+	 * Get the match data
+	 *
+	 * @return array<url_from: string, url_notfrom: string>
+	 */
 	private function get_from_data() {
 		return array(
 			'url_from' => $this->url_from,

--- a/models/redirect/redirect-sanitizer.php
+++ b/models/redirect/redirect-sanitizer.php
@@ -53,6 +53,8 @@ class Red_Item_Sanitize {
 		// Auto-migrate the regex to the source flags
 		$data['match_data'] = [ 'source' => [ 'flag_regex' => $data['regex'] === 1 ? true : false ] ];
 
+		$flags = new Red_Source_Flags();
+
 		// Set flags
 		if ( isset( $details['match_data'] ) && isset( $details['match_data']['source'] ) ) {
 			$defaults = red_get_options();
@@ -91,8 +93,13 @@ class Red_Item_Sanitize {
 		$data['url'] = $this->get_url( $url, $data['regex'] );
 
 		if ( ! is_wp_error( $data['url'] ) ) {
-			$data['match_url'] = new Red_Url_Match( $data['url'] );
-			$data['match_url'] = $data['match_url']->get_url();
+			$matcher = new Red_Url_Match( $data['url'] );
+			$data['match_url'] = $matcher->get_url();
+
+			// If 'exact order' then save the match URL with query params
+			if ( $flags->is_query_exact_order() ) {
+				$data['match_url'] = $matcher->get_url_with_params();
+			}
 		}
 
 		$data['title'] = ! empty( $details['title'] ) ? $details['title'] : null;

--- a/models/redirect/redirect.php
+++ b/models/redirect/redirect.php
@@ -422,12 +422,23 @@ class Red_Item {
 		return false;
 	}
 
+	/**
+	 * Disable all redirects that match the URL
+	 *
+	 * @param String $url URL to match.
+	 * @return void
+	 */
 	public static function disable_where_matches( $url ) {
 		global $wpdb;
 
 		$wpdb->update( $wpdb->prefix . 'redirection_items', array( 'status' => 'disabled' ), array( 'url' => $url ) );
 	}
 
+	/**
+	 * Delete this redirect
+	 *
+	 * @return void
+	 */
 	public function delete() {
 		global $wpdb;
 
@@ -437,6 +448,12 @@ class Red_Item {
 		Red_Module::flush( $this->group_id );
 	}
 
+	/**
+	 * Create a redirect with new details
+	 *
+	 * @param array $details Redirect details.
+	 * @return WP_Error|Red_Item
+	 */
 	public static function create( array $details ) {
 		global $wpdb;
 
@@ -527,7 +544,8 @@ class Red_Item {
 	/**
 	 * Determine if a requested URL matches this URL
 	 *
-	 * @param string $requested_url The URL being requested.
+	 * @param string       $requested_url The URL being requested.
+	 * @param string|false $original_url The original URL.
 	 * @return bool true if matched, false otherwise
 	 */
 	public function is_match( $requested_url, $original_url = false ) {
@@ -629,11 +647,11 @@ class Red_Item {
 		global $wpdb;
 
 		$this->last_count  = 0;
-		$this->last_access = '1970-01-01 00:00:00';
+		$this->last_access = 0;
 
 		$update = [
 			'last_count' => 0,
-			'last_access' => $this->last_access,
+			'last_access' => '1970-01-01 00:00:00',
 		];
 		$where = [
 			'id' => $this->id,

--- a/models/url/url-flags.php
+++ b/models/url/url-flags.php
@@ -13,18 +13,51 @@ class Red_Source_Flags {
 	const FLAG_TRAILING = 'flag_trailing';
 	const FLAG_REGEX = 'flag_regex';
 
+	/**
+	 * Case insensitive matching
+	 *
+	 * @var boolean
+	 */
 	private $flag_case = false;
+
+	/**
+	 * Ignored trailing slashes
+	 *
+	 * @var boolean
+	 */
 	private $flag_trailing = false;
+
+	/**
+	 * Regular expression
+	 *
+	 * @var boolean
+	 */
 	private $flag_regex = false;
 	private $flag_query = self::QUERY_EXACT;
+
+	/**
+	 * Values that have been set
+	 *
+	 * @var array
+	 */
 	private $values_set = [];
 
+	/**
+	 * Constructor
+	 *
+	 * @param array|null $json JSON object.
+	 */
 	public function __construct( $json = null ) {
-		if ( $json ) {
+		if ( $json !== null ) {
 			$this->set_flags( $json );
 		}
 	}
 
+	/**
+	 * Get list of valid query types as an array
+	 *
+	 * @return string[]
+	 */
 	private function get_allowed_query() {
 		return [
 			self::QUERY_IGNORE,
@@ -37,6 +70,7 @@ class Red_Source_Flags {
 	 * Parse flag data.
 	 *
 	 * @param array $json Flag data.
+	 * @return void
 	 */
 	public function set_flags( array $json ) {
 		if ( isset( $json[ self::FLAG_QUERY ] ) && in_array( $json[ self::FLAG_QUERY ], $this->get_allowed_query(), true ) ) {
@@ -64,30 +98,65 @@ class Red_Source_Flags {
 		$this->values_set = array_intersect( array_keys( $json ), array_keys( $this->get_json() ) );
 	}
 
+	/**
+	 * Return `true` if ignore trailing slash, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_ignore_trailing() {
 		return $this->flag_trailing;
 	}
 
+	/**
+	 * Return `true` if ignore case, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_ignore_case() {
 		return $this->flag_case;
 	}
 
+	/**
+	 * Return `true` if ignore trailing slash, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_regex() {
 		return $this->flag_regex;
 	}
 
+	/**
+	 * Return `true` if exact query match, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_query_exact() {
 		return $this->flag_query === self::QUERY_EXACT;
 	}
 
+	/**
+	 * Return `true` if ignore query params, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_query_ignore() {
 		return $this->flag_query === self::QUERY_IGNORE;
 	}
 
+	/**
+	 * Return `true` if ignore and pass query params, `false` otherwise
+	 *
+	 * @return boolean
+	 */
 	public function is_query_pass() {
 		return $this->flag_query === self::QUERY_PASS;
 	}
 
+	/**
+	 * Return the flags as a JSON object
+	 *
+	 * @return array
+	 */
 	public function get_json() {
 		return [
 			self::FLAG_QUERY => $this->flag_query,
@@ -101,6 +170,7 @@ class Red_Source_Flags {
 	 * Return flag data, with defaults removed from the data.
 	 *
 	 * @param array $defaults Defaults to remove.
+	 * @return array
 	 */
 	public function get_json_without_defaults( $defaults ) {
 		$json = $this->get_json();
@@ -118,6 +188,8 @@ class Red_Source_Flags {
 
 	/**
 	 * Return flag data, with defaults filling in any gaps not set.
+	 *
+	 * @return array
 	 */
 	public function get_json_with_defaults() {
 		$settings = red_get_options();

--- a/models/url/url-flags.php
+++ b/models/url/url-flags.php
@@ -7,6 +7,7 @@ class Red_Source_Flags {
 	const QUERY_IGNORE = 'ignore';
 	const QUERY_EXACT = 'exact';
 	const QUERY_PASS = 'pass';
+	const QUERY_EXACT_ORDER = 'exactorder';
 
 	const FLAG_QUERY = 'flag_query';
 	const FLAG_CASE = 'flag_case';
@@ -33,6 +34,12 @@ class Red_Source_Flags {
 	 * @var boolean
 	 */
 	private $flag_regex = false;
+
+	/**
+	 * Query parameter matching
+	 *
+	 * @var self::QUERY_EXACT|self::QUERY_IGNORE|self::QUERY_PASS|self::QUERY_EXACT_ORDER
+	 */
 	private $flag_query = self::QUERY_EXACT;
 
 	/**
@@ -63,6 +70,7 @@ class Red_Source_Flags {
 			self::QUERY_IGNORE,
 			self::QUERY_EXACT,
 			self::QUERY_PASS,
+			self::QUERY_EXACT_ORDER,
 		];
 	}
 
@@ -132,6 +140,15 @@ class Red_Source_Flags {
 	 */
 	public function is_query_exact() {
 		return $this->flag_query === self::QUERY_EXACT;
+	}
+
+	/**
+	 * Return `true` if exact query match in set order, `false` otherwise
+	 *
+	 * @return boolean
+	 */
+	public function is_query_exact_order() {
+		return $this->flag_query === self::QUERY_EXACT_ORDER;
 	}
 
 	/**

--- a/models/url/url-match.php
+++ b/models/url/url-match.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * Get a URL suitable for matching in the database
+ */
 class Red_Url_Match {
+	/**
+	 * URL
+	 *
+	 * @var String
+	 */
 	private $url;
 
+	/**
+	 * Constructor
+	 *
+	 * @param String $url The URL to match.
+	 */
 	public function __construct( $url ) {
 		$this->url = $url;
 	}
@@ -46,5 +59,16 @@ class Red_Url_Match {
 		$path = Red_Url_Path::to_lower( $path );
 
 		return $path ? $path : '/';
+	}
+
+	/**
+	 * Get the URL with parameters re-ordered into alphabetical order
+	 *
+	 * @return String
+	 */
+	public function get_url_with_params() {
+		$query = new Red_Url_Query( $this->url, new Red_Source_Flags( [ Red_Source_Flags::FLAG_CASE => true ] ) );
+
+		return $query->get_url_with_query( $this->get_url() );
 	}
 }

--- a/models/url/url-path.php
+++ b/models/url/url-path.php
@@ -118,14 +118,18 @@ class Red_Url_Path {
 		$qpos = strpos( $url, '?' );
 		$qrpos = strpos( $url, '\\?' );
 
+		// Have we found an escaped query and it occurs before a normal query?
 		if ( $qrpos !== false && $qrpos < $qpos ) {
-			return substr( $url, 0, $qrpos + strlen( $qrpos ) - 1 );
+			// Yes, the path is everything up to the escaped query
+			return substr( $url, 0, $qrpos );
 		}
 
+		// No query - return everything as path
 		if ( $qpos === false ) {
 			return $url;
 		}
 
+		// Query found - return everything up to it
 		return substr( $url, 0, $qpos );
 	}
 }

--- a/models/url/url-path.php
+++ b/models/url/url-path.php
@@ -1,12 +1,32 @@
 <?php
 
+/**
+ * The path part of a URL
+ */
 class Red_Url_Path {
+	/**
+	 * URL path
+	 *
+	 * @var String
+	 */
 	private $path;
 
+	/**
+	 * Constructor
+	 *
+	 * @param String $path URL.
+	 */
 	public function __construct( $path ) {
 		$this->path = $this->get_path_component( $path );
 	}
 
+	/**
+	 * Is the supplied `url` a match for this object?
+	 *
+	 * @param String           $url URL to match against.
+	 * @param Red_Source_Flags $flags Source flags to use in match.
+	 * @return boolean
+	 */
 	public function is_match( $url, Red_Source_Flags $flags ) {
 		$target = new Red_Url_Path( $url );
 
@@ -28,18 +48,34 @@ class Red_Url_Path {
 		return $target_path === $source_path;
 	}
 
+	/**
+	 * Convert a URL to lowercase
+	 *
+	 * @param String $url URL.
+	 * @return String
+	 */
 	public static function to_lower( $url ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
-			return mb_strtolower( $url );
+			return mb_strtolower( $url, 'UTF-8' );
 		}
 
 		return strtolower( $url );
 	}
 
+	/**
+	 * Get the path value
+	 *
+	 * @return String
+	 */
 	public function get() {
 		return $this->path;
 	}
 
+	/**
+	 * Get the path value without trailing slash, or `/` if home
+	 *
+	 * @return String
+	 */
 	public function get_without_trailing_slash() {
 		// Return / or // as-is
 		if ( $this->path === '/' ) {
@@ -50,8 +86,13 @@ class Red_Url_Path {
 		return preg_replace( '@/$@', '', $this->get() );
 	}
 
-	// parse_url doesn't handle 'incorrect' URLs, such as those with double slashes
-	// These are often used in redirects, so we fall back to our own parsing
+	/**
+	 * `parse_url` doesn't handle 'incorrect' URLs, such as those with double slashes
+	 * These are often used in redirects, so we fall back to our own parsing
+	 *
+	 * @param String $url URL.
+	 * @return String
+	 */
 	private function get_path_component( $url ) {
 		$path = $url;
 
@@ -67,6 +108,12 @@ class Red_Url_Path {
 		return urldecode( $this->get_query_before( $path ) );
 	}
 
+	/**
+	 * Get the path component up to the query string
+	 *
+	 * @param String $url URL.
+	 * @return String
+	 */
 	private function get_query_before( $url ) {
 		$qpos = strpos( $url, '?' );
 		$qrpos = strpos( $url, '\\?' );

--- a/models/url/url-query.php
+++ b/models/url/url-query.php
@@ -1,11 +1,34 @@
 <?php
 
+/**
+ * Query parameter martching
+ */
 class Red_Url_Query {
+	/**
+	 * @type Integer
+	 */
 	const RECURSION_LIMIT = 10;
 
+	/**
+	 * Query parameters
+	 *
+	 * @var array
+	 */
 	private $query = [];
+
+	/**
+	 * Is this an exact match?
+	 *
+	 * @var boolean
+	 */
 	private $match_exact = false;
 
+	/**
+	 * Constructor
+	 *
+	 * @param String           $url URL.
+	 * @param Red_Source_Flags $flags URL flags.
+	 */
 	public function __construct( $url, $flags ) {
 		if ( $flags->is_ignore_case() ) {
 			$url = Red_Url_Path::to_lower( $url );
@@ -14,6 +37,13 @@ class Red_Url_Query {
 		$this->query = $this->get_url_query( $url );
 	}
 
+	/**
+	 * Does this object match the URL?
+	 *
+	 * @param String           $url URL to match.
+	 * @param Red_Source_Flags $flags Source flags.
+	 * @return boolean
+	 */
 	public function is_match( $url, Red_Source_Flags $flags ) {
 		if ( $flags->is_ignore_case() ) {
 			$url = Red_Url_Path::to_lower( $url );
@@ -49,8 +79,8 @@ class Red_Url_Query {
 	/**
 	 * Pass query params from one URL to another URL, ignoring any params that already exist on the target.
 	 *
-	 * @param string $target_url The target URL to add params to.
-	 * @param string $requested_url The source URL to pass params from.
+	 * @param string           $target_url The target URL to add params to.
+	 * @param string           $requested_url The source URL to pass params from.
 	 * @param Red_Source_Flags $flags Any URL flags.
 	 * @return string URL, modified or not.
 	 */
@@ -86,10 +116,22 @@ class Red_Url_Query {
 		return $target_url;
 	}
 
+	/**
+	 * Get the query parameters
+	 *
+	 * @return Array
+	 */
 	public function get() {
 		return $this->query;
 	}
 
+	/**
+	 * Does the URL and the query params contain no parameters?
+	 *
+	 * @param String $url URL.
+	 * @param Array  $params Query params.
+	 * @return boolean
+	 */
 	private function is_exact_match( $url, $params ) {
 		// No parsed query params but we have query params on the URL - some parsing error with wp_parse_str
 		if ( count( $params ) === 0 && $this->has_query_params( $url ) ) {
@@ -99,6 +141,12 @@ class Red_Url_Query {
 		return false;
 	}
 
+	/**
+	 * Get query parameters from a URL
+	 *
+	 * @param String $url URL.
+	 * @return array
+	 */
 	private function get_url_query( $url ) {
 		$params = [];
 		$query = $this->get_query_after( $url );
@@ -112,6 +160,12 @@ class Red_Url_Query {
 		return $params;
 	}
 
+	/**
+	 * Does the URL contain query parameters?
+	 *
+	 * @param String $url URL.
+	 * @return boolean
+	 */
 	public function has_query_params( $url ) {
 		$qpos = strpos( $url, '?' );
 
@@ -122,10 +176,17 @@ class Red_Url_Query {
 		return true;
 	}
 
+	/**
+	 * Get parameters after the ?
+	 *
+	 * @param String $url URL.
+	 * @return String
+	 */
 	public function get_query_after( $url ) {
 		$qpos = strpos( $url, '?' );
 		$qrpos = strpos( $url, '\\?' );
 
+		// No ? anywhere - no query
 		if ( $qpos === false ) {
 			return '';
 		}
@@ -137,6 +198,14 @@ class Red_Url_Query {
 		return substr( $url, $qpos + 1 );
 	}
 
+	/**
+	 * Get query parameters that are the same in both query arrays
+	 *
+	 * @param array   $source_query Source query params.
+	 * @param array   $target_query Target query params.
+	 * @param integer $depth Current recursion depth.
+	 * @return array
+	 */
 	public function get_query_same( array $source_query, array $target_query, $depth = 0 ) {
 		if ( $depth > self::RECURSION_LIMIT ) {
 			return [];
@@ -166,6 +235,14 @@ class Red_Url_Query {
 		return $same;
 	}
 
+	/**
+	 * Get the difference in query parameters
+	 *
+	 * @param array   $source_query Source query params.
+	 * @param array   $target_query Target query params.
+	 * @param integer $depth Current recursion depth.
+	 * @return array
+	 */
 	public function get_query_diff( array $source_query, array $target_query, $depth = 0 ) {
 		if ( $depth > self::RECURSION_LIMIT ) {
 			return [];
@@ -173,8 +250,6 @@ class Red_Url_Query {
 
 		$diff = [];
 		foreach ( $source_query as $key => $value ) {
-			$found = false;
-
 			if ( isset( $target_query[ $key ] ) && is_array( $value ) && is_array( $target_query[ $key ] ) ) {
 				$add = $this->get_query_diff( $source_query[ $key ], $target_query[ $key ], $depth + 1 );
 

--- a/models/url/url-request.php
+++ b/models/url/url-request.php
@@ -1,9 +1,28 @@
 <?php
 
+/**
+ * Decode request URLs
+ */
 class Red_Url_Request {
+	/**
+	 * Original URL
+	 *
+	 * @var String
+	 */
 	private $original_url;
+
+	/**
+	 * Decoded URL
+	 *
+	 * @var String
+	 */
 	private $decoded_url;
 
+	/**
+	 * Constructor
+	 *
+	 * @param String $url URL.
+	 */
 	public function __construct( $url ) {
 		$this->original_url = apply_filters( 'redirection_url_source', $url );
 		$this->decoded_url = rawurldecode( $this->original_url );
@@ -33,20 +52,37 @@ class Red_Url_Request {
 		return $decoded_url;
 	}
 
+	/**
+	 * Get the original URL
+	 *
+	 * @return String
+	 */
 	public function get_original_url() {
 		return $this->original_url;
 	}
 
+	/**
+	 * Get the decoded URL
+	 *
+	 * @return String
+	 */
 	public function get_decoded_url() {
 		return $this->decoded_url;
 	}
 
+	/**
+	 * Is this a valid URL?
+	 *
+	 * @return boolean
+	 */
 	public function is_valid() {
 		return strlen( $this->get_decoded_url() ) > 0;
 	}
 
-	/*
+	/**
 	 * Protect certain URLs from being redirected. Note we don't need to protect wp-admin, as this code doesn't run there
+	 *
+	 * @return boolean
 	 */
 	public function is_protected_url() {
 		$rest = wp_parse_url( red_get_rest_api() );

--- a/models/url/url.php
+++ b/models/url/url.php
@@ -7,8 +7,18 @@ require_once __DIR__ . '/url-flags.php';
 require_once __DIR__ . '/url-request.php';
 
 class Red_Url {
+	/**
+	 * URL
+	 *
+	 * @var String
+	 */
 	private $url;
 
+	/**
+	 * Constructor
+	 *
+	 * @param string $url URL.
+	 */
 	public function __construct( $url = '' ) {
 		$this->url = $url;
 		$this->url = str_replace( ' ', '%20', $this->url );  // deprecated
@@ -26,8 +36,8 @@ class Red_Url {
 	/**
 	 * Match a target URL against the current URL, using any match flags
 	 *
-	 * @param string $requested_url Target URL
-	 * @param Red_Source_Flags $flags Match flags
+	 * @param string           $requested_url Target URL.
+	 * @param Red_Source_Flags $flags Match flags.
 	 * @return boolean
 	 */
 	public function is_match( $requested_url, Red_Source_Flags $flags ) {

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,9 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 
 An x.1 version increase introduces new or updated features and can be considered to contain 'breaking' changes. A x.x.1 increase is purely a bug fix and introduces no new features, and can be considered as containing no breaking changes.
 
+= 4.9.2 - ??? =
+* Improve display of long URLs
+
 = 4.9.1 - 26th October 2020 =
 * Restore missing time and referrer URL from log pages
 * Restore missing client information from debug reports

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,9 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 
 An x.1 version increase introduces new or updated features and can be considered to contain 'breaking' changes. A x.x.1 increase is purely a bug fix and introduces no new features, and can be considered as containing no breaking changes.
 
+= 4.10 - ??? =
+* Improve performance when many redirects have the same path
+
 = 4.9.2 - ??? =
 * Improve display of long URLs
 

--- a/tests/database/test-database-upgrade.php
+++ b/tests/database/test-database-upgrade.php
@@ -119,7 +119,8 @@ class DatabaseTester {
 			$rows = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_items" );
 
 			$unit->assertEquals( '/TEST/?thing=cat', $rows[0]->url );
-			$unit->assertEquals( '/test', $rows[0]->match_url );
+			$unit->assertEquals( '/test?thing=cat', $rows[0]->match_url );
+			$unit->assertEquals( '{"source":{"flag_query":"exactorder"}}', $rows[0]->match_data );
 
 			$unit->assertEquals( '/', $rows[1]->url );
 			$unit->assertEquals( '/', $rows[1]->match_url );

--- a/tests/models/test-url-path.php
+++ b/tests/models/test-url-path.php
@@ -48,6 +48,11 @@ class UrlPathTest extends WP_UnitTestCase {
 		$this->assertEquals( '/thing', $url->get() );
 	}
 
+	public function testEscapedQuery() {
+		$url = new Red_Url_Path( '/thing\\?this=query&more?another' );
+		$this->assertEquals( '/thing', $url->get() );
+	}
+
 	public function testRootQueryDouble() {
 		$url = new Red_Url_Path( '//?this=query&more' );
 		$this->assertEquals( '//', $url->get() );

--- a/tests/models/test-url-query.php
+++ b/tests/models/test-url-query.php
@@ -178,4 +178,27 @@ class UrlQueryTest extends WP_UnitTestCase {
 		$this->assertEquals( [], $url->get_query_diff( [ 'a' => [ 'a' => 'a' ] ], [ 'a' => [ 'a' => 'a' ] ] ) );
 		$this->assertEquals( [ 'a' => [ 'a' => 'a' ] ], $url->get_query_diff( [ 'a' => [ 'a' => 'a' ] ], [ 'a' => [ 'a' => 'b' ] ] ) );
 	}
+
+	public function testQueryAfterNone() {
+		$url = new Red_Url_Query( '', new Red_Source_Flags() );
+		$this->assertEquals( '', $url->get_query_after( '/no-query' ) );
+	}
+
+	public function testQueryAfterSingle() {
+		$url = new Red_Url_Query( '', new Red_Source_Flags() );
+		$this->assertEquals( 'cat', $url->get_query_after( '/query?cat' ) );
+	}
+
+	public function testQueryAfterEscaped() {
+		$url = new Red_Url_Query( '', new Red_Source_Flags() );
+		$this->assertEquals( 'cat', $url->get_query_after( '/query\\?cat' ) );
+	}
+
+	public function testQueryAfterBoth() {
+		$url = new Red_Url_Query( '', new Red_Source_Flags() );
+		$this->assertEquals( 'dog\\?cat', $url->get_query_after( '/query?dog\\?cat' ) );
+
+		$url = new Red_Url_Query( '', new Red_Source_Flags() );
+		$this->assertEquals( 'cat?cat', $url->get_query_after( '/query\\?cat?cat' ) );
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const BundleAnalyzerPlugin = require( 'webpack-bundle-analyzer' ).BundleAnalyzerPlugin;
+const TerserPlugin = require( 'terser-webpack-plugin' );
 
 // PostCSS plugins
 const postcssPresetEnv = require( 'postcss-preset-env' );
@@ -75,6 +76,17 @@ const config = {
 	},
 	optimization: {
 		minimize: isProduction(),
+		minimizer: [
+			new TerserPlugin( {
+				parallel: true,
+				extractComments: {
+					condition: true,
+					banner: () => {
+						return 'Redirection v' + pkg.version + ' - please refer to license.txt for license information';
+					},
+				},
+			} ),
+		],
 	},
 };
 


### PR DESCRIPTION
Add an 'exact order' match and use this to allow a redirect query to be stored in the `match_url` column. This means that a site with a lot of redirects that differ only by query param can improve performance by having exact matches.

The 4.0 DB upgrade is modified to use this by default, ensuring older sites continue to work the same.

