### PR TITLE
Add permalink migration support

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -14,6 +14,8 @@ if ! $(wp core is-installed); then
 	wp redirection database install
 	wp redirection import /opt/redirection/redirects.json
 	wp redirection setting headers --set='[{"type":"custom","location":"site","headerName":"X-Custom-Header","headerValue":"custom"},{"type":"X-Robots-Tag","location":"site","headerName":"X-Robots-Tag","headerValue":"nofollow"},{"type":"X-Robots-Tag","location":"redirect","headerName":"X-Robots-Tag","headerValue":"nofollow,noindex"}]'
+	wp redirection setting permalinks --set='["/%year%/%monthnum%/%day%/%postname%/"]'
+	wp post create --post_date='2020-01-01 07:00:00' --post_title='A post' --post_content='Just a small post.' --post_name='migrated-permalink' --post_status='publish' --post_author=1
 
 	echo "CLI: Setup finished"
 else

--- a/client/component/redirect-edit/warning.js
+++ b/client/component/redirect-edit/warning.js
@@ -25,7 +25,7 @@ export const isRegex = ( text ) => {
 	return false;
 };
 
-const getRelativeAbsolute = url => {
+const getRelativeAbsolute = ( url ) => {
 	const matched = url.match( /^\/([a-zA-Z0-9_\-%]*\..*)\// );
 
 	if ( matched ) {
@@ -49,7 +49,9 @@ export const getWarningFromState = ( item ) => {
 	// Anchor value
 	if ( url.indexOf( '#' ) !== -1 ) {
 		warnings.push(
-			<ExternalLink url="https://redirection.me/support/faq/#anchor">{ __( 'Anchor values are not sent to the server and cannot be redirected.' ) }</ExternalLink>,
+			<ExternalLink url="https://redirection.me/support/faq/#anchor">
+				{ __( 'Anchor values are not sent to the server and cannot be redirected.' ) }
+			</ExternalLink>
 		);
 	}
 
@@ -71,11 +73,13 @@ export const getWarningFromState = ( item ) => {
 
 	// Relative URL without leading slash
 	if ( url.substr( 0, 4 ) !== 'http' && url.substr( 0, 1 ) !== '/' && url.length > 0 && flag_regex === false ) {
-		warnings.push( __( 'The source URL should probably start with a {{code}}/{{/code}}', {
-			components: {
-				code: <code />,
-			},
-		} ) );
+		warnings.push(
+			__( 'The source URL should probably start with a {{code}}/{{/code}}', {
+				components: {
+					code: <code />,
+				},
+			} )
+		);
 	}
 
 	// Regex without checkbox
@@ -88,10 +92,12 @@ export const getWarningFromState = ( item ) => {
 	}
 
 	// Permalink
-	if ( url.indexOf( '%postname%' ) !== -1 ) {
+	if ( url.match( /%\w+%/ ) ) {
 		warnings.push(
-			<ExternalLink url="https://redirection.me/support/redirect-regular-expressions/">
-				{ __( 'WordPress permalink structures do not work in normal URLs. Please use a regular expression.' ) }
+			<ExternalLink url="tools.php?page=redirection.php&sub=site">
+				{ __(
+					'Please add migrated permalinks to the Site page under the "Permalink Migration" section.'
+				) }
 			</ExternalLink>
 		);
 	}
@@ -109,69 +115,104 @@ export const getWarningFromState = ( item ) => {
 	// Anchor
 	if ( url.indexOf( '^' ) === -1 && url.indexOf( '$' ) === -1 && flag_regex ) {
 		warnings.push(
-			__( 'To prevent a greedy regular expression you can use {{code}}^{{/code}} to anchor it to the start of the URL. For example: {{code}}%(example)s{{/code}}', {
-				components: {
-					code: <code />,
-				},
-				args: {
-					example: '^' + url,
-				},
-			} ),
+			__(
+				'To prevent a greedy regular expression you can use {{code}}^{{/code}} to anchor it to the start of the URL. For example: {{code}}%(example)s{{/code}}',
+				{
+					components: {
+						code: <code />,
+					},
+					args: {
+						example: '^' + url,
+					},
+				}
+			)
 		);
 	}
 
 	// Redirect everything
 	if ( url === '/(.*)' || url === '^/(.*)' ) {
-		warnings.push( __( 'If you want to redirect everything please use a site relocation or alias from the Site page.' ) );
+		warnings.push(
+			__( 'If you want to redirect everything please use a site relocation or alias from the Site page.' )
+		);
 	}
 
 	// If matched/unmatched that is the same as the source URL
-	if ( url.length > 0 && ( url_from === url || url_notfrom === url || logged_in === url || logged_out === url || targetUrl === url ) ) {
-		warnings.push( __( 'Your source is the same as a target and this will create a loop. Leave a target blank if you do not want to take action.' ) );
+	if (
+		url.length > 0 &&
+		( url_from === url || url_notfrom === url || logged_in === url || logged_out === url || targetUrl === url )
+	) {
+		warnings.push(
+			__(
+				'Your source is the same as a target and this will create a loop. Leave a target blank if you do not want to take action.'
+			)
+		);
 	}
 
-	const targets = [ action_data.url, action_data.url_from, action_data.url_notfrom, action_data.logged_in, action_data.logged_out ].filter( filt => filt );
+	const targets = [
+		action_data.url,
+		action_data.url_from,
+		action_data.url_notfrom,
+		action_data.logged_in,
+		action_data.logged_out,
+	].filter( ( filt ) => filt );
 
-	if ( targetUrl && ! beginsWith( targetUrl, 'https://' ) && ! beginsWith( targetUrl, 'http://' ) && targetUrl.substr( 0, 1 ) !== '/' ) {
-		warnings.push( __( 'Your target URL should be an absolute URL like {{code}}https://domain.com/%(url)s{{/code}} or start with a slash {{code}}/%(url)s{{/code}}.', {
-			components: {
-				code: <code />,
-			},
-			args: {
-				url: action_data.url,
-			},
-		} ) );
+	if (
+		targetUrl &&
+		! beginsWith( targetUrl, 'https://' ) &&
+		! beginsWith( targetUrl, 'http://' ) &&
+		targetUrl.substr( 0, 1 ) !== '/'
+	) {
+		warnings.push(
+			__(
+				'Your target URL should be an absolute URL like {{code}}https://domain.com/%(url)s{{/code}} or start with a slash {{code}}/%(url)s{{/code}}.',
+				{
+					components: {
+						code: <code />,
+					},
+					args: {
+						url: action_data.url,
+					},
+				}
+			)
+		);
 	}
 
-	targets.forEach( target => {
+	targets.forEach( ( target ) => {
 		const matches = target.match( /[|\\]/g );
 
 		if ( matches !== null ) {
-			warnings.push( __( 'Your target URL contains the invalid character {{code}}%(invalid)s{{/code}}', {
-				components: {
-					code: <code />,
-				},
-				args: {
-					invalid: matches,
-				},
-			} ) );
+			warnings.push(
+				__( 'Your target URL contains the invalid character {{code}}%(invalid)s{{/code}}', {
+					components: {
+						code: <code />,
+					},
+					args: {
+						invalid: matches,
+					},
+				} )
+			);
 		}
 	} );
 
 	// People often try and use a relative absolute domain - /something.com/
-	[ url, ... targets ].forEach( target => {
+	[ url, ...targets ].forEach( ( target ) => {
 		const relative = getRelativeAbsolute( target );
 
 		if ( relative ) {
-			warnings.push( __( 'Your URL appears to contain a domain inside the path: {{code}}%(relative)s{{/code}}. Did you mean to use {{code}}%(absolute)s{{/code}} instead?', {
-				components: {
-					code: <code />,
-				},
-				args: {
-					relative,
-					absolute: 'https://' + relative,
-				},
-			} ) );
+			warnings.push(
+				__(
+					'Your URL appears to contain a domain inside the path: {{code}}%(relative)s{{/code}}. Did you mean to use {{code}}%(absolute)s{{/code}} instead?',
+					{
+						components: {
+							code: <code />,
+						},
+						args: {
+							relative,
+							absolute: 'https://' + relative,
+						},
+					}
+				)
+			);
 		}
 	} );
 
@@ -179,7 +220,9 @@ export const getWarningFromState = ( item ) => {
 	if ( url.match( /(\.html|\.htm|\.php|\.pdf|\.jpg)$/ ) !== null ) {
 		warnings.push(
 			<ExternalLink url="https://redirection.me/support/problems/url-not-redirecting/">
-				{ __( 'Some servers may be configured to serve file resources directly, preventing a redirect occurring.' ) }
+				{ __(
+					'Some servers may be configured to serve file resources directly, preventing a redirect occurring.'
+				) }
 			</ExternalLink>
 		);
 	}
@@ -195,7 +238,12 @@ export const Warnings = ( { warnings } ) => {
 	return (
 		<TableRow>
 			<div className="redirect-edit_warning notice notice-warning">
-				{ warnings.map( ( text, pos ) => <p key={ pos }><span className="dashicons dashicons-info"></span>{ text }</p> ) }
+				{ warnings.map( ( text, pos ) => (
+					<p key={ pos }>
+						<span className="dashicons dashicons-info" />
+						{ text }
+					</p>
+				) ) }
 			</div>
 		</TableRow>
 	);

--- a/client/page/site/canonical/index.js
+++ b/client/page/site/canonical/index.js
@@ -2,9 +2,8 @@
  * External dependencies
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 
 const getWWW = ( site ) => [
 	{
@@ -72,7 +71,7 @@ function getCanonical( domain, https, preferred ) {
 	return ( https ? 'https://' : 'http://' ) + domain;
 }
 
-const CanonicalSettings = ( { https, preferredDomain, siteDomain, onChange } ) => {
+function CanonicalSettings( { https, preferredDomain, siteDomain, onChange } ) {
 	const alert = showAlert( siteDomain, https, preferredDomain );
 	const changePreferred = ev => {
 		onChange( { [ ev.target.name ]: ev.target.value } );
@@ -82,7 +81,7 @@ const CanonicalSettings = ( { https, preferredDomain, siteDomain, onChange } ) =
 	};
 
 	return (
-		<Fragment>
+		<>
 			<h3>{ __( 'Canonical Settings' ) }</h3>
 			<p>
 				<label>
@@ -127,15 +126,8 @@ const CanonicalSettings = ( { https, preferredDomain, siteDomain, onChange } ) =
 					},
 				} ) }</p>
 			</div> }
-		</Fragment>
+		</>
 	);
-}
-
-CanonicalSettings.propTypes = {
-	https: PropTypes.bool.isRequired,
-	preferredDomain: PropTypes.string.isRequired,
-	siteDomain: PropTypes.string.isRequired,
-	onChange: PropTypes.func.isRequired,
 }
 
 export default CanonicalSettings;

--- a/client/page/site/index.js
+++ b/client/page/site/index.js
@@ -19,6 +19,7 @@ import CanonicalSettings from './canonical';
 import HttpHeaders from './headers';
 import { getDomainOnly, getDomainAndPathOnly } from 'lib/url';
 import './style.scss';
+import PermalinkSettings from './permalink';
 
 class Site extends React.Component {
 	constructor( props ) {
@@ -26,7 +27,7 @@ class Site extends React.Component {
 
 		props.onLoadSettings();
 
-		const { headers = [], relocate = '', preferred_domain = '', https = false, aliases = [] } = props.values ? props.values : {};
+		const { headers = [], relocate = '', preferred_domain = '', https = false, aliases = [], permalinks = [] } = props.values ? props.values : {};
 
 		this.state = {
 			https,
@@ -34,11 +35,12 @@ class Site extends React.Component {
 			headers,
 			relocate,
 			aliases,
+			permalinks,
 		};
 	}
 
 	onSubmit = ev => {
-		const { https, headers, preferred_domain, aliases, relocate } = this.state;
+		const { https, headers, preferred_domain, aliases, relocate, permalinks } = this.state;
 
 		ev.preventDefault();
 		this.props.onSaveSettings( {
@@ -46,7 +48,8 @@ class Site extends React.Component {
 			headers,
 			preferred_domain,
 			aliases: aliases.filter( item => item ).map( getDomainOnly ),
-			relocate: getDomainAndPathOnly( relocate )
+			relocate: getDomainAndPathOnly( relocate ),
+			permalinks,
 		} );
 	}
 
@@ -56,7 +59,7 @@ class Site extends React.Component {
 
 	render() {
 		const { loadStatus, values, saveStatus, siteDomain } = this.props;
-		const { headers, relocate, aliases, https, preferred_domain } = this.state;
+		const { headers, relocate, aliases, https, preferred_domain, permalinks } = this.state;
 
 		if ( loadStatus === STATUS_IN_PROGRESS || ! values ) {
 			return <Placeholder />;
@@ -65,20 +68,45 @@ class Site extends React.Component {
 		return (
 			<form onSubmit={ this.onSubmit }>
 				<div className="inline-notice inline-warning">
-					<p>{ __( 'Options on this page can cause problems if used incorrectly. You can {{link}}temporarily disable them{{/link}} to make changes.', {
-						components: {
-							link: <ExternalLink url="https://redirection.me/support/disable-redirection/" />,
-						},
-					} ) }</p>
+					<p>
+						{ __(
+							'Options on this page can cause problems if used incorrectly. You can {{link}}temporarily disable them{{/link}} to make changes.',
+							{
+								components: {
+									link: (
+										<ExternalLink url="https://redirection.me/support/disable-redirection/" />
+									),
+								},
+							}
+						) }
+					</p>
 				</div>
 
 				<RelocateSite relocate={ relocate } siteDomain={ siteDomain } onChange={ this.onChange } />
-				{ relocate.length === 0 && <SiteAliases aliases={ aliases } siteDomain={ siteDomain } onChange={ this.onChange } /> }
-				{ relocate.length === 0 && <CanonicalSettings https={ https } siteDomain={ siteDomain } preferredDomain={ preferred_domain } onChange={ this.onChange } /> }
+				{ relocate.length === 0 && (
+					<SiteAliases aliases={ aliases } siteDomain={ siteDomain } onChange={ this.onChange } />
+				) }
+				{ relocate.length === 0 && (
+					<CanonicalSettings
+						https={ https }
+						siteDomain={ siteDomain }
+						preferredDomain={ preferred_domain }
+						onChange={ this.onChange }
+					/>
+				) }
+				{ relocate.length === 0 && (
+					<PermalinkSettings permalinks={ permalinks } onChange={ this.onChange } />
+				) }
 
 				<HttpHeaders headers={ headers } onChange={ this.onChange } />
 
-				<input className="button-primary" type="submit" name="update" value={ __( 'Update' ) } disabled={ saveStatus === STATUS_IN_PROGRESS } />
+				<input
+					className="button-primary"
+					type="submit"
+					name="update"
+					value={ __( 'Update' ) }
+					disabled={ saveStatus === STATUS_IN_PROGRESS }
+				/>
 			</form>
 		);
 	}

--- a/client/page/site/permalink/index.js
+++ b/client/page/site/permalink/index.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Local dependencies
+ */
+
+import Permalink from './permalink';
+
+const PERMALINK_MAX = 10;
+
+const addPermalink = ( permalinks, onChange, ev ) => {
+	ev.preventDefault();
+
+	onChange( { permalinks: permalinks.concat( '' ).slice( 0, PERMALINK_MAX ) } );
+};
+
+const removePermalink = ( pos, permalinks, onChange ) => {
+	onChange( { permalinks: [ ...permalinks.slice( 0, pos ), ...permalinks.slice( pos + 1 ) ] } );
+};
+
+const updatePermalink = ( pos, permalinks, onChange, ev ) => {
+	const updated = permalinks.slice();
+
+	updated[ pos ] = ev.target.value;
+
+	onChange( { permalinks: updated } );
+};
+
+function PermalinkSettings( props ) {
+	const { permalinks, onChange } = props;
+
+	return (
+		<>
+			<h3>{ __( 'Permalink Migration' ) }</h3>
+			<p>{ __( 'Enter old permalinks structures to automatically migrate them to your current one.' ) }</p>
+			<p>{ __( 'Note: this is beta and will only migrate posts.' ) }</p>
+
+			<table className="wp-list-table widefat fixed striped items redirect-aliases table-auto">
+				<thead>
+					<tr>
+						<th>{ __( 'Permalinks' ) }</th>
+						<th className="redirect-alias__delete" />
+					</tr>
+				</thead>
+
+				<tbody>
+					{ permalinks.map( ( link, key ) => (
+						<Permalink
+							key={ key }
+							link={ link }
+							onChange={ ( ev ) => updatePermalink( key, permalinks, onChange, ev ) }
+							onDelete={ () => removePermalink( key, permalinks, onChange ) }
+						/>
+					) ) }
+					{ permalinks.length === 0 && (
+						<tr>
+							<td colSpan={ 2 }>{ __( 'No migrated permalinkss' ) }</td>
+						</tr>
+					) }
+				</tbody>
+			</table>
+
+			<p>
+				<button className="button-secondary" onClick={ ( ev ) => addPermalink( permalinks, onChange, ev ) }>
+					{ __( 'Add Permalink' ) }
+				</button>
+			</p>
+		</>
+	);
+}
+
+export default PermalinkSettings;

--- a/client/page/site/permalink/permalink.js
+++ b/client/page/site/permalink/permalink.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+function Permalink( { link, onChange, onDelete } ) {
+	const deleteIt = ( ev ) => {
+		ev.preventDefault();
+		onDelete();
+	};
+
+	return (
+		<tr className="redirect-alias__item">
+			<td>
+				<input className="regular-text" type="text" name="link" value={ link } onChange={ onChange } />
+			</td>
+			<td className="redirect-alias__delete">
+				<button onClick={ deleteIt }>
+					<span className="dashicons dashicons-trash" />
+				</button>
+			</td>
+		</tr>
+	);
+};
+
+export default Permalink;

--- a/e2e/__tests__/url.json
+++ b/e2e/__tests__/url.json
@@ -438,5 +438,18 @@
 				"agent": true
 			}
 		}
+	],
+	[
+		"Test a migrated permalink",
+		{
+			"source": {
+				"url": "/2020/01/01/migrated-permalink/"
+			},
+			"target": {
+				"location": "/migrated-permalink/",
+				"status": 301,
+				"agent": true
+			}
+		}
 	]
 ]

--- a/models/permalinks.php
+++ b/models/permalinks.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Provides permalink migration facilities
+ */
+class Red_Permalinks {
+	/**
+	 * List of migrated permalink structures
+	 *
+	 * @var string[]
+	 */
+	private $permalinks = [];
+
+	/**
+	 * Current permalink structure
+	 *
+	 * @var string|null
+	 */
+	private $current_permalink = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string[] $permalinks List of migrated permalinks.
+	 */
+	public function __construct( $permalinks ) {
+		$this->permalinks = $permalinks;
+	}
+
+	/**
+	 * Match and migrate any permalinks
+	 *
+	 * @param WP_Query $query Query.
+	 * @return void
+	 */
+	public function migrate( WP_Query $query ) {
+		global $wp;
+
+		if ( count( $this->permalinks ) === 0 ) {
+			return;
+		}
+
+		$this->intercept_permalinks();
+
+		foreach ( $this->permalinks as $old ) {
+			// Set the current permalink
+			$this->current_permalink = $old;
+
+			// Run the WP query again
+			$wp->init();
+			$wp->parse_request();
+
+			// Anything matched?
+			if ( $wp->matched_rule ) {
+				// Perform the post query
+				$wp->query_posts();
+
+				// A single post?
+				if ( is_single() ) {
+					// Restore permalinks
+					$this->release_permalinks();
+
+					// Get real URL from the post ID
+					$url = get_permalink( $query->posts[0]->ID );
+					if ( $url ) {
+						wp_safe_redirect( $url, 301, 'redirection' );
+						die();
+					}
+				}
+
+				break;
+			}
+		}
+
+		$this->release_permalinks();
+	}
+
+	/**
+	 * Hook the permalink options and return the migrated one
+	 *
+	 * @return void
+	 */
+	private function intercept_permalinks() {
+		add_filter( 'pre_option_rewrite_rules', [ $this, 'get_old_rewrite_rules' ] );
+		add_filter( 'pre_option_permalink_structure', [ $this, 'get_old_permalink' ] );
+	}
+
+	/**
+	 * Restore the hooked option
+	 *
+	 * @return void
+	 */
+	private function release_permalinks() {
+		remove_filter( 'pre_option_rewrite_rules', [ $this, 'get_old_rewrite_rules' ] );
+		remove_filter( 'pre_option_permalink_structure', [ $this, 'get_old_permalink' ] );
+	}
+
+	/**
+	 * Returns rewrite rules for the current migrated permalink
+	 *
+	 * @param array $rules Current rules.
+	 * @return array
+	 */
+	public function get_old_rewrite_rules( $rules ) {
+		global $wp_rewrite;
+
+		if ( $this->current_permalink ) {
+			$wp_rewrite->init();
+			$wp_rewrite->matches = 'matches';
+			return $wp_rewrite->rewrite_rules();
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Get the current migrated permalink structure
+	 *
+	 * @param string $result Current value.
+	 * @return string
+	 */
+	public function get_old_permalink( $result ) {
+		if ( $this->current_permalink ) {
+			return $this->current_permalink;
+		}
+
+		return $result;
+	}
+}

--- a/models/permalinks.php
+++ b/models/permalinks.php
@@ -56,7 +56,7 @@ class Red_Permalinks {
 				$wp->query_posts();
 
 				// A single post?
-				if ( is_single() ) {
+				if ( is_single() && count( $query->posts ) > 0 ) {
 					// Restore permalinks
 					$this->release_permalinks();
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,10 @@ Errors can be grouped to show where you should focus your attention, and can be 
 
 You can match query parameters exactly, ignore them, and even pass them through to your target.
 
+= Migrate Permalinks =
+
+Changed your permalink structure? You can migrate old permalinks simply by entering the old permalink structure. Multiple migrations are supported.
+
 = Apache & Nginx support =
 
 By default Redirection will manage all redirects using WordPress. However you can configure it so redirects are automatically saved to a .htaccess file and handled by Apache itself.
@@ -179,6 +183,7 @@ An x.1 version increase introduces new or updated features and can be considered
 
 = 4.10 - ??? =
 * Improve performance when many redirects have the same path
+* Add support for migrated permalink structures
 
 = 4.9.2 - ??? =
 * Improve display of long URLs

--- a/redirection-settings.php
+++ b/redirection-settings.php
@@ -62,6 +62,7 @@ function red_get_default_options() {
 		'relocate'            => '',
 		'preferred_domain'    => '',
 		'aliases'             => [],
+		'permalinks'          => [],
 	];
 	$defaults = array_merge( $defaults, $flags->get_json() );
 
@@ -196,7 +197,12 @@ function red_set_options( array $settings = array() ) {
 
 	if ( isset( $settings['aliases'] ) && is_array( $settings['aliases'] ) ) {
 		$options['aliases'] = array_values( array_filter( array_map( 'red_parse_domain_only', $settings['aliases'] ) ) );
-		$options['aliases'] = array_slice( $options['aliases'], 0, 10 ); // Max 10 aliases
+		$options['aliases'] = array_slice( $options['aliases'], 0, 10 ); // Max 10
+	}
+
+	if ( isset( $settings['permalinks'] ) && is_array( $settings['permalinks'] ) ) {
+		$options['permalinks'] = array_values( array_filter( array_map( 'trim', $settings['permalinks'] ) ) );
+		$options['permalinks'] = array_slice( $options['permalinks'], 0, 10 ); // Max 10
 	}
 
 	if ( isset( $settings['preferred_domain'] ) && in_array( $settings['preferred_domain'], [ '', 'www', 'nowww' ], true ) ) {


### PR DESCRIPTION
Allow old permalink structures to be added. If a request is made to a page that would otherwise return a 404 then we check the old permalink and see if a match is made. If it is we then redirect to the currrent permalink structure.

Fixes #476
