### PR TITLE
Fix the default page with restricted caps

### DIFF
--- a/client/page/groups/columns/index.js
+++ b/client/page/groups/columns/index.js
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { numberFormat } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function getColumns( row, rowParams, disabled ) {
 		},
 		{
 			name: 'redirects',
-			content: redirects,
+			content: numberFormat( redirects, 0 ),
 		},
 		{
 			name: 'module',

--- a/client/page/home/index.js
+++ b/client/page/home/index.js
@@ -84,11 +84,7 @@ const getMenu = () =>
 		( option ) => has_page_access( option.value ) || ( option.value === '' && has_page_access( 'redirect' ) )
 	);
 
-const ALLOWED_PAGES = [ 'redirect' ].concat(
-	getMenu()
-		.slice( 1 )
-		.map( ( page ) => page.value )
-);
+const ALLOWED_PAGES = Redirectioni10n?.caps?.pages || [];
 
 function Home( props ) {
 	const {

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ An x.1 version increase introduces new or updated features and can be considered
 * Add fully automatic database upgrade option
 * Improve performance when many redirects have the same path
 * Move bulk all action to a seperate button after selecting all
+* Fix error in display with restricted capabilities
 
 = 4.9.2 - 30th October =
 * Fix warning with PHP 5.6


### PR DESCRIPTION
It was forcing the default page to be ‘redirects’, and if you didn’t have access to that page it would error.