### PR TITLE
Fix invalid URL encoding and fragment handling

### DIFF
--- a/models/redirect/redirect-sanitizer.php
+++ b/models/redirect/redirect-sanitizer.php
@@ -241,17 +241,37 @@ class Red_Item_Sanitize {
 			$url = '/' . $url;
 		}
 
-		// Ensure we URL decode any i10n characters
-		$url = rawurldecode( $url );
+		// Try and URL decode any i10n characters
+		$decoded = $this->remove_bad_encoding( rawurldecode( $url ) );
 
-		// Try and remove bad decoding
-		if ( function_exists( 'iconv' ) ) {
-			$converted = @iconv( 'UTF-8', 'UTF-8//IGNORE', $url );
-			if ( $converted !== false ) {
-				$url = $converted;
+		// Was there any invalid characters?
+		if ( $decoded === false ) {
+			// Yes. Use the url as an undecoded URL, and check for invalid characters
+			$decoded = $this->remove_bad_encoding( $url );
+
+			// Was there any invalid characters?
+			if ( $decoded === false ) {
+				// Yes, it's still a problem. Use the URL as-is and hope for the best
+				return $url;
 			}
 		}
 
-		return $url;
+		// Return the URL
+		return $decoded;
+	}
+
+	/**
+	 * Remove any bad encoding, where possible
+	 *
+	 * @param string $text Text.
+	 * @return string|false
+	 */
+	private function remove_bad_encoding( $text ) {
+		// Try and remove bad decoding
+		if ( function_exists( 'iconv' ) ) {
+			return @iconv( 'UTF-8', 'UTF-8//IGNORE', $text );
+		}
+
+		return $text;
 	}
 }

--- a/models/url/url-query.php
+++ b/models/url/url-query.php
@@ -123,6 +123,18 @@ class Red_Url_Query {
 		$query = preg_replace( '@%5B\d*%5D@', '[]', $query );  // Make these look like []
 
 		if ( $query ) {
+			// Get any fragment
+			$target_fragment = wp_parse_url( $url, PHP_URL_FRAGMENT );
+
+			// If we have a fragment we need to ensure it comes after the query parameters, not before
+			if ( $target_fragment ) {
+				// Remove fragment
+				$url = str_replace( '#' . $target_fragment, '', $url );
+
+				// Add to the end of the query
+				$query .= '#' . $target_fragment;
+			}
+
 			return $url . ( strpos( $url, '?' ) === false ? '?' : '&' ) . $query;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -179,7 +179,7 @@ The plugin works in a similar manner to how WordPress handles permalinks and sho
 
 == Changelog ==
 
-An x.1 version increase introduces new or updated features and can be considered to contain 'breaking' changes. A x.x.1 increase is purely a bug fix and introduces no new features, and can be considered as containing no breaking changes.
+A x.1 version increase introduces new or updated features and can be considered to contain 'breaking' changes. A x.x.1 increase is purely a bug fix and introduces no new features, and can be considered as containing no breaking changes.
 
 = 5.0 - ??? =
 * Add caching support
@@ -190,6 +190,7 @@ An x.1 version increase introduces new or updated features and can be considered
 * Move bulk all action to a seperate button after selecting all
 * Fix error in display with restricted capabilities
 * Avoid problems with 7G Firewall
+* Improve handling of invalid encoded characters
 
 = 4.9.2 - 30th October =
 * Fix warning with PHP 5.6

--- a/tests/models/test-url-query.php
+++ b/tests/models/test-url-query.php
@@ -108,6 +108,10 @@ class UrlQueryTest extends WP_UnitTestCase {
 		$this->assertEquals( '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3', Red_Url_Query::add_to_target( '/', '/?arrs1[]=1&arrs1[]=2&arrs1[]=3&arrs2[]=1&arrs2[]=2&arrs2[]=3', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
 	}
 
+	public function testFragment() {
+		$this->assertEquals( '/?arrs1[]=1&arrs1[]=2&stuff=1#fragment', Red_Url_Query::add_to_target( '/#fragment', '/?arrs1[]=1&arrs1[]=2&stuff=1', new Red_Source_Flags( [ 'flag_query' => 'pass' ] ) ) );
+	}
+
 	public function testQueryDoubleSlash() {
 		$url = new Red_Url_Query( '//?this=query&more', new Red_Source_Flags() );
 		$this->assertEquals( [


### PR DESCRIPTION
Fixes two problems with URLs:

- Query parameters not added correctly when URL contains a fragment
- Invalid URL characters handled too strictly. If an invalid character is passed URL encoded then leave it alone