### PR TITLE
Exporting error (4xx/5xx) entries to Nginx config

### DIFF
--- a/fileio/nginx.php
+++ b/fileio/nginx.php
@@ -131,9 +131,16 @@ class Red_Nginx_File extends Red_FileIO {
 			}
 			// And re-anchor url
 			$line = '^' . $line . '$';
-		// For exact match...
+		// For non-regex...
 		} else {
-			$modifier = '=';
+			// Escape and use as regex for case insensitivity
+			if ( isset( $source['flag_case'] ) && $source['flag_case'] ) {
+				$modifier = '~*';
+				$line = '^' . preg_quote($line) . '$';
+			// Otherwise use exact match
+			} else {
+				$modifier = '=';
+			}
 		}
 
 		return 'location ' . $modifier . ' ' . $line . ' { return ' . $code . '; }';

--- a/tests/fileio/test-nginx.php
+++ b/tests/fileio/test-nginx.php
@@ -100,7 +100,7 @@ class NginxTest extends WP_UnitTestCase {
 	}
 
 	public function testErrorRegexCaseInsensitive() {
-		$match_data = json_encode( [ 'source' => [ 'flag_case' => true ] ] );
+		$match_data = json_encode( [ 'source' => [ 'flag_case' => true, 'flag_regex' => true ] ] );
 		$nginx = new Red_Nginx_File();
 		$redirects = array( new Red_Item( ( object )array( 'match_type' => 'url', 'id' => 1, 'regex' => true, 'action_type' => 'error', 'url' => '^/test.*', 'action_code' => 403, 'match_data' => $match_data, 'status' => 'enabled' ) ) );
 

--- a/tests/fileio/test-nginx.php
+++ b/tests/fileio/test-nginx.php
@@ -60,4 +60,54 @@ class NginxTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 'rewrite (?i)^/test$ /target permanent;', trim( $lines[5] ) );
 	}
+
+	public function testError() {
+		$nginx = new Red_Nginx_File();
+		$redirects = array( new Red_Item( ( object )array( 'match_type' => 'url', 'id' => 1, 'action_type' => 'error', 'url' => '/test', 'action_code' => 410, 'status' => 'enabled' ) ) );
+
+		$file = $nginx->get_data( $redirects, array() );
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( count( $lines ), 10 );
+		$this->assertEquals( '# Created by Redirection', trim( $lines[0] ) );
+		$this->assertEquals( 'server {', trim( $lines[4] ) );
+		$this->assertEquals( 'location = /test { return 410; }', trim( $lines[5] ) );
+		$this->assertEquals( '}', trim( $lines[ count( $lines ) - 4 ] ) );
+		$this->assertEquals( '# End of Redirection', trim( $lines[ count( $lines ) - 2 ] ) );
+	}
+
+	public function testErrorRegex() {
+		$nginx = new Red_Nginx_File();
+		$redirects = array( new Red_Item( ( object )array( 'match_type' => 'url', 'id' => 1, 'regex' => true, 'action_type' => 'error', 'url' => '^/test.*', 'action_code' => 418, 'status' => 'enabled' ) ) );
+
+		$file = $nginx->get_data( $redirects, array() );
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( count( $lines ), 10 );
+		$this->assertEquals( 'location ~ ^/test.*$ { return 418; }', trim( $lines[5] ) );
+	}
+
+	public function testErrorCaseInsensitive() {
+		$match_data = json_encode( [ 'source' => [ 'flag_case' => true ] ] );
+		$nginx = new Red_Nginx_File();
+		$redirects = array( new Red_Item( ( object )array( 'match_type' => 'url', 'id' => 1, 'action_type' => 'error', 'url' => '/test.php', 'action_code' => 451, 'match_data' => $match_data, 'status' => 'enabled' ) ) );
+
+		$file = $nginx->get_data( $redirects, array() );
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( count( $lines ), 10 );
+		$this->assertEquals( 'location ~* ^/test\.php$ { return 451; }', trim( $lines[5] ) );
+	}
+
+	public function testErrorRegexCaseInsensitive() {
+		$match_data = json_encode( [ 'source' => [ 'flag_case' => true ] ] );
+		$nginx = new Red_Nginx_File();
+		$redirects = array( new Red_Item( ( object )array( 'match_type' => 'url', 'id' => 1, 'regex' => true, 'action_type' => 'error', 'url' => '^/test.*', 'action_code' => 403, 'match_data' => $match_data, 'status' => 'enabled' ) ) );
+
+		$file = $nginx->get_data( $redirects, array() );
+		$lines = explode( "\n", $file );
+
+		$this->assertEquals( count( $lines ), 10 );
+		$this->assertEquals( 'location ~* ^/test.*$ { return 403; }', trim( $lines[5] ) );
+	}
 }


### PR DESCRIPTION
Error code redirects (eg, a `410` to "kill" a url for SEO purposes or a `451` for legal takedowns) are not correctly exported in the nginx format, which this PR aims to fix.

## Example data

Given this set of examples (a single redirect, the rest are error codes):

<img width="657" alt="Screen Shot 2020-12-24 at 2 49 51 PM" src="https://user-images.githubusercontent.com/84145/103111286-3e0e4900-4600-11eb-8914-a468a30a5341.png">

## What happens now

They're currently exported as `rewrite` directives without a target, all of which will effectively 404:

<img width="641" alt="Screen Shot 2020-12-24 at 3 54 38 PM" src="https://user-images.githubusercontent.com/84145/103111390-5cc10f80-4601-11eb-921e-b823a85506d9.png">

## Ideal output

Instead, a `location` block returning the error code seems to do the trick:

<img width="622" alt="Screen Shot 2020-12-24 at 3 54 58 PM" src="https://user-images.githubusercontent.com/84145/103111400-7febbf00-4601-11eb-9b45-98f1bf6ddcda.png">

Note that, for non-regex entries tagged with case insensitivity, the easiest way to accomplish that was to use it as an (escaped) regex with a case insensitive modifier (`~*`). Any other non-regex can use the exact match modifier (`=`).

## Loose ends

I've added some tests for these cases, but was unable to run them locally to verify ahead of time. 🤞 