### PR TITLE
PHP8 compatible wp-cli registration

### DIFF
--- a/redirection-cli.php
+++ b/redirection-cli.php
@@ -292,11 +292,9 @@ class Redirection_Cli extends WP_CLI_Command {
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	WP_CLI::add_command( 'redirection import', [ 'Redirection_Cli', 'import' ] );
-	WP_CLI::add_command( 'redirection export', [ 'Redirection_Cli', 'export' ] );
-	WP_CLI::add_command( 'redirection database', [ 'Redirection_Cli', 'database' ] );
-	WP_CLI::add_command( 'redirection setting', [ 'Redirection_Cli', 'setting' ] );
-	WP_CLI::add_command( 'redirection plugin', [ 'Redirection_Cli', 'plugin' ] );
+
+	// Register "redirection" as top-level command, and all public methods as sub-commands
+	WP_CLI::add_command( 'redirection', 'Redirection_Cli' );
 
 	add_action( Red_Flusher::DELETE_HOOK, function() {
 		$flusher = new Red_Flusher();


### PR DESCRIPTION
Fix for critical bug where wp-cli triggers an error running php8:
```
Error: Callable ["Redirection_Cli","import"] does not exist, and cannot be registered as "wp redirection import"
```
Error is triggered because "import", "database" etc are non-static methods, and [since php8.0 calling instance methods statically isn't allowed](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other)

Fix follows [example](https://make.wordpress.org/cli/handbook/guides/commands-cookbook/#annotating-with-phpdoc) from official documentation, which also makes code more DRY

