### PR TITLE
Fixed check for testing same query when the query variable key is not…

### DIFF
--- a/models/url/url-query.php
+++ b/models/url/url-query.php
@@ -281,9 +281,9 @@ class Red_Url_Query {
 				$add = false;
 
 				if ( is_array( $source_value ) && is_array( $target_value ) ) {
-					$add = $this->get_query_same( $source_query[ $key ], $target_value, $is_ignore_case, $depth + 1 );
+					$add = $this->get_query_same( $source_value, $target_value, $is_ignore_case, $depth + 1 );
 
-					if ( count( $add ) !== count( $source_query[ $key ] ) ) {
+					if ( count( $add ) !== count( $source_value ) ) {
 						$add = false;
 					}
 				} elseif ( is_string( $source_value ) && is_string( $target_value ) ) {


### PR DESCRIPTION
… all lowercase

Fix for an issue that occurs when a query argument's key is not all lowercase, causing a fatal error since `$source_query` won't have an index of `$key` (it actually has index `$original_key`). This causes a fatal error as a non-array value gets passed into `get_query_same`.