### PR TITLE
Allow user to not set associated_redirect value

### DIFF
--- a/redirection-settings.php
+++ b/redirection-settings.php
@@ -117,8 +117,12 @@ function red_set_options( array $settings = [] ) {
 	}
 
 	if ( isset( $settings['associated_redirect'] ) && is_string( $settings['associated_redirect'] ) ) {
-		$sanitizer = new Red_Item_Sanitize();
-		$options['associated_redirect'] = trim( $sanitizer->sanitize_url( $settings['associated_redirect'] ) );
+		$options['associated_redirect'] == '';
+
+		if ( strlen( $settings['associated_redirect'] ) > 0 ) {
+			$sanitizer = new Red_Item_Sanitize();
+			$options['associated_redirect'] = trim( $sanitizer->sanitize_url( $settings['associated_redirect'] ) );
+		}
 	}
 
 	if ( isset( $settings['monitor_types'] ) && count( $monitor_types ) === 0 ) {

--- a/redirection-settings.php
+++ b/redirection-settings.php
@@ -117,7 +117,7 @@ function red_set_options( array $settings = [] ) {
 	}
 
 	if ( isset( $settings['associated_redirect'] ) && is_string( $settings['associated_redirect'] ) ) {
-		$options['associated_redirect'] == '';
+		$options['associated_redirect'] = '';
 
 		if ( strlen( $settings['associated_redirect'] ) > 0 ) {
 			$sanitizer = new Red_Item_Sanitize();


### PR DESCRIPTION
This PR addresses #3541.

Right now, if the user tries to remove the value from the `associated_redirect` field in the URL Monitor Changes section of the plugin options, the value is set to a trailing slash on save. As a result, when a user triggers the URL monitor by changing a post slug, two redirect entries are created.

[This commit](https://github.com/johngodley/redirection/commit/2d89b4702fb2d86420321616f4de135d74ca30b3#diff-03f15b1fc2b15d80272040930cb996e076590b464bb42687726aed7199be8e29L119-R121) that landed in version 5.3.7 removed the logic that only passed the `associated_redirect` value through `Red_Item_Sanitize::sanitize_url()` if the value had at least one character. Since `Red_Item_Sanitize::sanitize_url()` ensures the value starts with a trailing slash, the slash is added to the empty value.

This PR restores that logic, allowing the user to leave the `associated_redirect` field empty.