### PR TITLE
hook(redirection_export_items) Introduce 2 filters on items list before export

### DIFF
--- a/models/file-io.php
+++ b/models/file-io.php
@@ -76,6 +76,8 @@ abstract class Red_FileIO {
 		if ( $module_name_or_id === 'all' || $module_name_or_id === 0 ) {
 			$groups = Red_Group::get_all();
 			$items = Red_Item::get_all();
+
+			$items = self::filter_items_to_export( 'all', $items );
 		} else {
 			$module_name_or_id = is_numeric( $module_name_or_id ) ? $module_name_or_id : Red_Module::get_id_for_name( $module_name_or_id );
 			$module = Red_Module::get( intval( $module_name_or_id, 10 ) );
@@ -83,6 +85,8 @@ abstract class Red_FileIO {
 			if ( $module ) {
 				$groups = Red_Group::get_all_for_module( $module->get_id() );
 				$items = Red_Item::get_all_for_module( $module->get_id() );
+
+				$items = self::filter_items_to_export( $module->get_name(), $items );
 			}
 		}
 
@@ -96,6 +100,13 @@ abstract class Red_FileIO {
 		}
 
 		return false;
+	}
+
+	private static function filter_items_to_export( $module_name, $items ) {
+		$items = apply_filters( 'redirection_export_items', $items );
+		$items = apply_filters( 'redirection_export_items_' . $module_name, $items );
+
+		return $items;
 	}
 
 	abstract public function get_data( array $items, array $groups );

--- a/models/file-io.php
+++ b/models/file-io.php
@@ -77,7 +77,8 @@ abstract class Red_FileIO {
 			$groups = Red_Group::get_all();
 			$items = Red_Item::get_all();
 
-			$items = self::filter_items_to_export( 'all', $items );
+			$groups = self::filter_groups_to_export( 'all', $groups );
+			$items = self::filter_items_to_export( 'all', $items, $groups );
 		} else {
 			$module_name_or_id = is_numeric( $module_name_or_id ) ? $module_name_or_id : Red_Module::get_id_for_name( $module_name_or_id );
 			$module = Red_Module::get( intval( $module_name_or_id, 10 ) );
@@ -86,7 +87,8 @@ abstract class Red_FileIO {
 				$groups = Red_Group::get_all_for_module( $module->get_id() );
 				$items = Red_Item::get_all_for_module( $module->get_id() );
 
-				$items = self::filter_items_to_export( $module->get_name(), $items );
+				$groups = self::filter_groups_to_export( $module->get_name(), $groups );
+				$items = self::filter_items_to_export( $module->get_name(), $items, $groups );
 			}
 		}
 
@@ -102,11 +104,18 @@ abstract class Red_FileIO {
 		return false;
 	}
 
-	private static function filter_items_to_export( $module_name, $items ) {
-		$items = apply_filters( 'redirection_export_items', $items );
-		$items = apply_filters( 'redirection_export_items_' . $module_name, $items );
+	private static function filter_items_to_export( $module_name, $items, $groups ) {
+		$items = apply_filters( 'redirection_export_items', $items, $groups );
+		$items = apply_filters( 'redirection_export_items_' . $module_name, $items, $groups );
 
 		return $items;
+	}
+
+	private static function filter_groups_to_export( $module_name, $groups ) {
+		$groups = apply_filters( 'redirection_export_groups', $groups );
+		$groups = apply_filters( 'redirection_export_groups_' . $module_name, $groups );
+
+		return $groups;
 	}
 
 	abstract public function get_data( array $items, array $groups );


### PR DESCRIPTION
The goal is that an external plugin is able to adds/deletes redirect rules before export.

This way, plugins can dynamically adds rules without adding it to the database (that users may change through the UI).