### PR TITLE
Return correct parameters for redirection_redirect_updated action ( $id => ID of redirect item,  $redirect => Red_Item redirect object)

### DIFF
--- a/models/redirect/redirect.php
+++ b/models/redirect/redirect.php
@@ -544,7 +544,7 @@ class Red_Item {
 
 		$result = $wpdb->update( $wpdb->prefix . 'redirection_items', $data, array( 'id' => $this->id ) );
 		if ( $result !== false ) {
-			do_action( 'redirection_redirect_updated', $this, self::get_by_id( $this->id ) );
+			do_action( 'redirection_redirect_updated', $this->id, self::get_by_id( $this->id ) );
 			$this->load_from_data( $data );
 
 			Red_Module::flush( $this->group_id );


### PR DESCRIPTION
Updated **redirection_redirect_updated** action to return the parameters as described in the documentation. Currently it returns Red_Item redirect object twice.
