### PR TITLE
Add Live Preview Blueprint for WordPress.org

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/tools.php?page=redirection.php",
+  "preferredVersions": {
+    "php": "8.3",
+    "wp": "latest"
+  },
+  "extraLibraries": [
+    "wp-cli"
+  ],
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin"
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "blogname": "Redirection Playground Demo",
+        "permalink_structure": "/%postname%/"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "redirection"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/demo-redirects.htaccess",
+      "data": "Redirect 301 /old-promo/ /new-promo/\nRedirect 302 /out-of-stock/ /docs/\n"
+    },
+    {
+      "step": "wp-cli",
+      "command": "wp redirection database install"
+    },
+    {
+      "step": "wp-cli",
+      "command": "wp redirection import /wordpress/demo-redirects.htaccess --format=apache"
+    },
+    {
+      "step": "wp-cli",
+      "command": "wp post create --post_type=page --post_status=publish --post_name=new-promo --post_title='New promo landing (Redirection demo)' --post_content='You reached this page via a redirect created by the Redirection plugin in this Playground demo.'"
+    },
+    {
+      "step": "wp-cli",
+      "command": "wp post create --post_type=page --post_status=publish --post_name=docs --post_title='Docs landing (Redirection demo)' --post_content='This page is the 302 target for /out-of-stock/, configured via the Redirection plugin.'"
+    }
+  ]
+}


### PR DESCRIPTION
Hi! I noticed that Redirection doesn't have a Live Preview button on its WordPress.org page yet, so I created a blueprint configuration for it.

## About Live Preview

The [Live Preview feature](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) allows users to try plugins directly in their browser without installing anything, powered by [WordPress Playground](https://playground.wordpress.net/). This can significantly increase user engagement and conversions.

**Learn more:**
- [Plugin Handbook - Previews and Blueprints](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/)
- [WordPress Playground Documentation](https://wordpress.github.io/wordpress-playground/)

## What's Included

This PR adds `.wordpress-org/blueprints/blueprint.json` which configures the preview to:
- Install and activate Redirection
- Log users in automatically
- Direct them to the Redirection management page
- Import demo redirects (301 and 302 examples)
- Create target pages to demonstrate working redirects

## Testing the Blueprint

You can test this blueprint right now in WordPress Playground (before merging):

<a href="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/redirection/add-wordpress-playground-blueprint/.wordpress-org/blueprints/blueprint.json"><img alt="Try it in Playground" width="300" src="https://raw.githubusercontent.com/WordPress/action-wp-playground-pr-preview/80f4a8b6d7ee3248abf09d373de965117a015ee0/assets/playground-preview-button.svg"></a>

This lets you see exactly how users will experience the Live Preview!

## How to Enable

After merging this PR and syncing to your WordPress.org SVN repository at `/assets/blueprints/blueprint.json`:

1. Log in to your WordPress.org account
2. Go to [your plugin's Advanced page](https://wordpress.org/plugins/redirection/advanced/)
3. Scroll to **"Toggle Live Preview"**
4. Set the preview to **"public"**

The Live Preview button will then appear on your plugin page!

You can also test before enabling publicly by adding `?preview=1` to your plugin URL: https://wordpress.org/plugins/redirection/?preview=1

## Note on SVN Deployment

Since this repository uses a build process, you'll need to ensure the `.wordpress-org` directory is deployed to SVN's `/assets` directory. This can be done by either:

1. **Option A (Recommended):** Update the `release` script in `package.json` to include the `.wordpress-org` directory: ```bash cp -R .wordpress-org release/ ```

2. **Option B:** Manually copy `.wordpress-org` to the SVN `assets/` directory after running `yarn dist:svn`: ```bash yarn dist:svn cd svn mkdir -p assets/blueprints cp ../../../.wordpress-org/blueprints/blueprint.json assets/blueprints/ svn add assets/blueprints/blueprint.json svn ci ```

## Customization

Feel free to customize the blueprint to better showcase your plugin's features. You can:
- Change the landing page
- Add demo content or sample data
- Configure specific PHP/WordPress versions
- Add setup steps

See the [Blueprint documentation](https://wordpress.github.io/wordpress-playground/blueprints-api/index) for all available options.

---

Let me know if you'd like any adjustments to better showcase Redirection!