### PR TITLE
Fix support for spaces in htaccess

### DIFF
--- a/models/htaccess.php
+++ b/models/htaccess.php
@@ -86,9 +86,9 @@ class Red_Htaccess {
 		$allowed = [
 			'%2F' => '/',
 			'%3F' => '?',
-			'+' => ' ',
+			'+' => '\\s',
 			'.' => '\\.',
-			'%20' => ' ',
+			'%20' => '\\s',
 		];
 
 		return $this->replace_encoding( rawurlencode( $url ), $allowed );
@@ -107,8 +107,8 @@ class Red_Htaccess {
 		// Remove invalid characters
 		$url = (string) preg_replace( '/[^\PC\s]/u', '', $url );
 
-		// Make sure spaces are quoted
-		// $url = str_replace( ' ', '%20', $url );
+		// Make sure spaces are escaped as \s for regex matching
+		$url = str_replace( ' ', '\\s', $url );
 		$url = str_replace( '%24', '$', $url );
 
 		// No leading slash

--- a/tests/integration/fileio/test-htaccess.php
+++ b/tests/integration/fileio/test-htaccess.php
@@ -347,4 +347,39 @@ and a line at the end';
 		$this->assertEquals( 'RewriteCond %{HTTP_HOST} ^otherdomain\.com$ [NC]', trim( $lines[5] ) );
 		$this->assertEquals( 'RewriteRule ^test$ /target [R=301,L]', trim( $lines[6] ) );
 	}
+
+	public function testRedirectUrlWithSpaces() {
+		$htaccess = new Red_Htaccess();
+		$item = new Red_Item( (object) array(
+			'match_type' => 'url',
+			'id' => 1,
+			'action_type' => 'url',
+			'url' => '/my test url',
+			'action_data' => '/target',
+			'action_code' => 301,
+		) );
+		$htaccess->add( $item );
+
+		$lines = $this->getOutput( $htaccess );
+
+		$this->assertEquals( 'RewriteRule ^my\stest\surl$ /target [R=301,L]', trim( $lines[5] ) );
+	}
+
+	public function testRedirectUrlRegexWithSpaces() {
+		$htaccess = new Red_Htaccess();
+		$item = new Red_Item( (object) array(
+			'match_type' => 'url',
+			'id' => 1,
+			'action_type' => 'url',
+			'url' => '/my test.*',
+			'action_code' => 301,
+			'action_data' => '/target',
+			'regex' => true,
+		) );
+		$htaccess->add( $item );
+
+		$lines = $this->getOutput( $htaccess );
+
+		$this->assertEquals( 'RewriteRule my\stest.* /target [R=301,L]', trim( $lines[5] ) );
+	}
 }


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/apache-redirects-does-not-parse-spaces-in-urls/