### PR TITLE
Prevent null monitor posts

### DIFF
--- a/models/monitor.php
+++ b/models/monitor.php
@@ -54,11 +54,16 @@ class Red_Monitor {
 	}
 
 	/**
-	 * @param WP_Post $post
-	 * @param WP_Post $post_before
+	 * @param WP_Post|null $post
+	 * @param WP_Post|null $post_before
 	 * @return bool
 	 */
-	public function can_monitor_post( WP_Post $post, WP_Post $post_before ): bool {
+	public function can_monitor_post( ?WP_Post $post, ?WP_Post $post_before ): bool {
+		// Defensive check: ensure we have valid post objects
+		if ( $post === null || $post_before === null ) {
+			return false;
+		}
+
 		// Check this is for the expected post
 		// @phpstan-ignore isset.property
 		if ( ! isset( $post->ID ) || ! isset( $this->updated_posts[ $post->ID ] ) ) {
@@ -82,11 +87,16 @@ class Red_Monitor {
 	 * Called when a post has been updated - check if the slug has changed
 	 *
 	 * @param int $post_id
-	 * @param WP_Post $post
-	 * @param WP_Post $post_before
+	 * @param WP_Post|null $post
+	 * @param WP_Post|null $post_before
 	 * @return void
 	 */
-	public function post_updated( int $post_id, WP_Post $post, WP_Post $post_before ): void {
+	public function post_updated( int $post_id, ?WP_Post $post, ?WP_Post $post_before ): void {
+		// WordPress may pass null during trash/delete operations - handle gracefully
+		if ( $post === null || $post_before === null ) {
+			return;
+		}
+
 		if ( isset( $this->updated_posts[ $post_id ] ) && $this->can_monitor_post( $post, $post_before ) ) {
 			$this->check_for_modified_slug( $post_id, $this->updated_posts[ $post_id ] );
 		}

--- a/tests/integration/models/test-monitor.php
+++ b/tests/integration/models/test-monitor.php
@@ -211,6 +211,20 @@ class MonitorTest extends WP_UnitTestCase {
 		$this->assertEquals( $total, $after );
 	}
 
+	public function testPostUpdatedWithNullPostExitsCleanly() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions() );
+		$total = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" );
+
+		$monitor->post_updated( $this->post_id, null, null );
+		$monitor->post_updated( $this->post_id, $this->getPublishedPost(), null );
+		$monitor->post_updated( $this->post_id, null, $this->getPublishedPost() );
+
+		$after = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" );
+		$this->assertEquals( $total, $after );
+	}
+
 	public function testNoHooks() {
 		$monitor = new Red_Monitor( array( 'monitor_post' => 0, 'monitor_types' => array() ) );
 


### PR DESCRIPTION
On some sites they receive a null post, which causes the tighter type requirements to fail.

Fixes #4127