### PR TITLE
Fix incorrect passing of filter params in select all

### DIFF
--- a/src/page/groups/index.tsx
+++ b/src/page/groups/index.tsx
@@ -79,7 +79,7 @@ function Groups() {
 
 		if ( table.selectAll ) {
 			// Apply action to all items matching current filters
-			const params = { global: true, ...table.filterBy };
+			const params = { global: true, filterBy: table.filterBy };
 			groupBulkAction.mutate( { action, items: [], params } );
 		} else {
 			// Apply action to selected items only

--- a/src/page/logs/index.tsx
+++ b/src/page/logs/index.tsx
@@ -118,7 +118,7 @@ function Logs() {
 
 		if ( table.selectAll ) {
 			// Delete all items matching current filters
-			logBulkAction.mutate( { action, items: [], params: { ...params, global: true, ...table.filterBy } } );
+			logBulkAction.mutate( { action, items: [], params: { ...params, global: true, filterBy: table.filterBy } } );
 		} else {
 			// Delete only selected items
 			logBulkAction.mutate( { action, items: table.selected, params } );

--- a/src/page/logs/index.tsx
+++ b/src/page/logs/index.tsx
@@ -118,7 +118,11 @@ function Logs() {
 
 		if ( table.selectAll ) {
 			// Delete all items matching current filters
-			logBulkAction.mutate( { action, items: [], params: { ...params, global: true, filterBy: table.filterBy } } );
+			logBulkAction.mutate( {
+				action,
+				items: [],
+				params: { ...params, global: true, filterBy: table.filterBy },
+			} );
 		} else {
 			// Delete only selected items
 			logBulkAction.mutate( { action, items: table.selected, params } );

--- a/src/page/logs404/index.tsx
+++ b/src/page/logs404/index.tsx
@@ -136,7 +136,7 @@ function Logs404() {
 				errorBulkAction.mutate( {
 					action: 'delete',
 					items: [],
-					params: { ...params, global: true, ...table.filterBy },
+					params: { ...params, global: true, filterBy: table.filterBy },
 				} );
 			} else {
 				// Delete only selected items

--- a/src/page/redirects/index.tsx
+++ b/src/page/redirects/index.tsx
@@ -129,7 +129,7 @@ function Redirects() {
 
 		if ( table.selectAll ) {
 			// Apply action to all items matching current filters
-			const params = { global: true, ...table.filterBy };
+			const params = { global: true, filterBy: table.filterBy };
 			switch ( action ) {
 				case 'delete':
 					deleteMutation.mutate( { items: [], params } );


### PR DESCRIPTION
The filterby param was being incorrectly passed to the select all bulk action.

Fixes #4169 