### PR TITLE
Fix: prevent action_code=0 from causing wp_die() on redirects

### DIFF
--- a/models/redirect/redirect-sanitizer.php
+++ b/models/redirect/redirect-sanitizer.php
@@ -166,8 +166,8 @@ class Red_Item_Sanitize {
 			return new WP_Error( 'redirect', 'Invalid redirect action' );
 		}
 
-		$data['action_type'] = sanitize_text_field( $details['action_type'] );
-		$data['action_code'] = $this->get_code( $details['action_type'], $action_code );
+		$data['action_type'] = isset( $details['action_type'] ) ? sanitize_text_field( $details['action_type'] ) : '';
+		$data['action_code'] = $this->get_code( $data['action_type'], $action_code );
 
 		if ( isset( $details['action_data'] ) && is_array( $details['action_data'] ) ) {
 			$match_data = $matcher->save( $details['action_data'] ? $details['action_data'] : array(), ! $this->is_url_type( $data['action_type'] ) );
@@ -246,7 +246,9 @@ class Red_Item_Sanitize {
 			return 404;
 		}
 
-		return 0;
+		// Default to 301 for unknown action types to prevent wp_redirect() from
+		// calling wp_die() when it receives a non-3xx status code.
+		return 301;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `get_code()` in `redirect-sanitizer.php` returns `0` as its default fallback when `action_type` doesn't match `'url'`, `'random'`, or `'error'`. Since WordPress 6.4+, `wp_redirect()` validates the status code and calls `wp_die("HTTP redirect status code must be a redirection code, 3xx.")` when it receives a non-3xx code, producing a **500 error** for end users.
- Lines 169-170 access `$details['action_type']` without an `isset()` guard. On PHP 8+, this produces `null`, which bypasses both the `'url'` and `'error'` branches in `get_code()` and hits the `return 0` fallback.

## Reproduction

When the `monitor_post` feature auto-creates redirects on slug changes, the stored `action_type` is `'url'` but the `action_code` ends up as `0`. Any request matching these rules triggers `wp_redirect($url, 0)` → `wp_die()` → HTTP 500.

We observed this on a WooCommerce site with 48 auto-generated redirect rules (all in the Modified Posts group) that had `action_code = 0`, causing 500 errors for real users arriving from search engines.

## Fix

1. Add `isset()` guard on `$details['action_type']` and pass the already-sanitized `$data['action_type']` to `get_code()` instead of the raw value
2. Change the default fallback in `get_code()` from `0` to `301` — a status code of `0` is never valid for HTTP redirects

## Test plan

- [ ] Verify existing redirect rules with valid `action_type` and `action_code` are unaffected
- [ ] Create a redirect with an unrecognized `action_type` — should default to `301` instead of `0`
- [ ] Confirm no `wp_die()` on redirect execution


🤖 Generated with [Claude Code](https://claude.com/claude-code)