### PR TITLE
Allow editing disabled redirects

### DIFF
--- a/src/page/redirects/row-actions.tsx
+++ b/src/page/redirects/row-actions.tsx
@@ -38,7 +38,7 @@ function RedirectRowActions( props: RedirectRowActionsProps ) {
 		return null;
 	}
 
-	if ( enabled && has_capability( CAP_REDIRECT_ADD ) ) {
+	if ( has_capability( CAP_REDIRECT_ADD ) ) {
 		menu.push(
 			<RowAction key="1" onClick={ () => setRowMode( 'edit' ) }>
 				{ __( 'Edit', 'redirection' ) }


### PR DESCRIPTION
## Summary

Fixes #4106.

Currently the Edit action in the redirect row menu is only shown when a redirect is enabled. This forces users to re-enable a redirect, make their edits, then disable it again — an unnecessary extra step.

The fix removes the `enabled &&` guard from the Edit action condition in `row-actions.tsx`, so the Edit button appears for both enabled and disabled redirects. The capability check (`CAP_REDIRECT_ADD`) is preserved, and the Enable/Disable toggle is unaffected.

The "Check Redirect" action intentionally keeps its `enabled` guard since checking a live redirect doesn't make sense when it's disabled.

## Changes

- `src/page/redirects/row-actions.tsx`: remove `enabled &&` from the Edit row action condition

## Test plan

- [ ] Create a redirect and disable it
- [ ] Confirm the Edit action appears in the row menu
- [ ] Edit the redirect while disabled — changes save correctly
- [ ] Confirm the redirect remains disabled after editing
- [ ] Confirm Edit still works for enabled redirects
- [ ] Confirm "Check Redirect" is still only shown for enabled redirects