### PR TITLE
Include group name in CSV export and resolve it on import

### DIFF
--- a/fileio/csv.php
+++ b/fileio/csv.php
@@ -20,6 +20,7 @@ class Red_Csv_File extends Red_FileIO {
 	const CSV_TARGET = 1;
 	const CSV_REGEX = 2;
 	const CSV_CODE = 3;
+	const CSV_GROUP = 8;
 
 	public function force_download() {
 		parent::force_download();
@@ -34,20 +35,26 @@ class Red_Csv_File extends Red_FileIO {
 	 * @return string
 	 */
 	public function get_data( array $items, array $groups ) {
-		$lines = [ implode( ',', array( 'source', 'target', 'regex', 'code', 'type', 'hits', 'title', 'status' ) ) ];
+		$lines = [ implode( ',', array( 'source', 'target', 'regex', 'code', 'type', 'hits', 'title', 'status', 'group' ) ) ];
+
+		$group_names = [];
+		foreach ( $groups as $group ) {
+			$group_names[ $group['id'] ] = $group['name'];
+		}
 
 		foreach ( $items as $line ) {
-			$lines[] = $this->item_as_csv( $line );
+			$lines[] = $this->item_as_csv( $line, $group_names );
 		}
 
 		return implode( PHP_EOL, $lines ) . PHP_EOL;
 	}
 
 	/**
-	 * @param Red_Item $item
+	 * @param Red_Item             $item
+	 * @param array<int, string>   $group_names Map of group ID to group name.
 	 * @return string
 	 */
-	public function item_as_csv( $item ) {
+	public function item_as_csv( $item, array $group_names = [] ) {
 		$data = [];
 
 		if ( $item->match !== null ) {
@@ -64,6 +71,7 @@ class Red_Csv_File extends Red_FileIO {
 			$data = '';
 		}
 
+		$group_id = $item->get_group_id();
 		$csv = array(
 			$item->get_url(),
 			$data,
@@ -73,6 +81,7 @@ class Red_Csv_File extends Red_FileIO {
 			$item->get_hits(),
 			$item->get_title(),
 			$item->is_enabled() ? 'active' : 'disabled',
+			isset( $group_names[ $group_id ] ) ? $group_names[ $group_id ] : '',
 		);
 
 		$csv = array_map( array( $this, 'escape_csv' ), $csv );
@@ -137,6 +146,14 @@ class Red_Csv_File extends Red_FileIO {
 
 		/** @var Red_Group $group */
 
+		$all_groups = Red_Group::get_all();
+		$groups_by_name = [];
+		if ( $all_groups !== false ) {
+			foreach ( $all_groups as $g ) {
+				$groups_by_name[ $g['name'] ] = $g['id'];
+			}
+		}
+
 		while ( ( $csv = fgetcsv( $file, 5000, $separator ) ) !== false ) {
 			if ( $csv === null ) {
 				continue;
@@ -149,7 +166,7 @@ class Red_Csv_File extends Red_FileIO {
 				},
 				$csv
 			);
-			$item = $this->csv_as_item( $csv, $group );
+			$item = $this->csv_as_item( $csv, $group, $groups_by_name );
 
 			if ( $item !== false && $this->item_is_valid( $item ) ) {
 				$created = Red_Item::create( $item );
@@ -207,19 +224,25 @@ class Red_Csv_File extends Red_FileIO {
 	}
 
 	/**
-	 * @param array<int, string> $csv
-	 * @param Red_Group          $group
+	 * @param array<int, string>   $csv
+	 * @param Red_Group            $group         Fallback group from the import UI.
+	 * @param array<string, int>   $groups_by_name Map of group name to group ID for name-based lookup.
 	 * @return CsvItem|false
 	 */
-	public function csv_as_item( $csv, Red_Group $group ) {
+	public function csv_as_item( $csv, Red_Group $group, array $groups_by_name = [] ) {
 		if ( count( $csv ) > 1 && $csv[ self::CSV_SOURCE ] !== 'source' && $csv[ self::CSV_TARGET ] !== 'target' ) {
 			$code = isset( $csv[ self::CSV_CODE ] ) ? $this->get_valid_code( $csv[ self::CSV_CODE ] ) : 301;
+
+			$group_id = $group->get_id();
+			if ( isset( $csv[ self::CSV_GROUP ] ) && $csv[ self::CSV_GROUP ] !== '' && isset( $groups_by_name[ $csv[ self::CSV_GROUP ] ] ) ) {
+				$group_id = $groups_by_name[ $csv[ self::CSV_GROUP ] ];
+			}
 
 			return array(
 				'url' => trim( $csv[ self::CSV_SOURCE ] ),
 				'action_data' => array( 'url' => trim( $csv[ self::CSV_TARGET ] ) ),
 				'regex' => isset( $csv[ self::CSV_REGEX ] ) ? $this->parse_regex( $csv[ self::CSV_REGEX ] ) : $this->is_regex( $csv[ self::CSV_SOURCE ] ),
-				'group_id' => $group->get_id(),
+				'group_id' => $group_id,
 				'match_type' => 'url',
 				'action_type' => $this->get_action_type( $code ),
 				'action_code' => $code,

--- a/src/page/redirects/row-actions.tsx
+++ b/src/page/redirects/row-actions.tsx
@@ -38,7 +38,7 @@ function RedirectRowActions( props: RedirectRowActionsProps ) {
 		return null;
 	}
 
-	if ( enabled && has_capability( CAP_REDIRECT_ADD ) ) {
+	if ( has_capability( CAP_REDIRECT_ADD ) ) {
 		menu.push(
 			<RowAction key="1" onClick={ () => setRowMode( 'edit' ) }>
 				{ __( 'Edit', 'redirection' ) }

--- a/tests/integration/fileio/test-csv.php
+++ b/tests/integration/fileio/test-csv.php
@@ -6,7 +6,7 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source', 'action_data' => '/target', 'action_code' => 301 ) );
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active"', $csv );
+		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active",""', $csv );
 	}
 
 	public function testRegex() {
@@ -14,7 +14,7 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => true, 'action_type' => 'url', 'url' => '/source', 'action_data' => '/target', 'action_code' => 301 ) );
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"/source","/target",1,301,"url",0,"","active"', $csv );
+		$this->assertEquals( '"/source","/target",1,301,"url",0,"","active",""', $csv );
 	}
 
 	public function testEscapeFormula() {
@@ -22,7 +22,7 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '=/source', 'action_data' => '/target', 'action_code' => 301 ) );
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"=/source","/target",0,301,"url",0,"","active"', $csv );
+		$this->assertEquals( '"=/source","/target",0,301,"url",0,"","active",""', $csv );
 	}
 
 	public function testEscapeCSVEmpty() {
@@ -48,9 +48,9 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$lines = array_filter( explode( PHP_EOL, $result ) );
 
 		$this->assertEquals( 3, count( $lines ) );
-		$this->assertEquals( 'source,target,regex,code,type,hits,title,status', $lines[0] );
-		$this->assertEquals( '"/source1","/target",0,301,"url",0,"","active"', $lines[1] );
-		$this->assertEquals( '"/source2","/target",0,301,"url",0,"","active"', $lines[2] );
+		$this->assertEquals( 'source,target,regex,code,type,hits,title,status,group', $lines[0] );
+		$this->assertEquals( '"/source1","/target",0,301,"url",0,"","active",""', $lines[1] );
+		$this->assertEquals( '"/source2","/target",0,301,"url",0,"","active",""', $lines[2] );
 	}
 
 	public function testExportReferrer() {
@@ -59,7 +59,7 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item = new Red_Item( (object) array( 'match_type' => 'referrer', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source1', 'action_data' => $target, 'action_code' => 301 ) );
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"/source1","/unknown",0,301,"url",0,"","active"', $csv );
+		$this->assertEquals( '"/source1","/unknown",0,301,"url",0,"","active",""', $csv );
 	}
 
 	public function testEnabled() {
@@ -68,7 +68,7 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item->enable();
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active"', $csv );
+		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active",""', $csv );
 	}
 
 	public function testDisabled() {
@@ -77,6 +77,6 @@ class ExportCsvTest extends WP_UnitTestCase {
 		$item->disable();
 		$csv = $exporter->item_as_csv( $item );
 
-		$this->assertEquals( '"/source","/target",0,301,"url",0,"","disabled"', $csv );
+		$this->assertEquals( '"/source","/target",0,301,"url",0,"","disabled",""', $csv );
 	}
 }

--- a/tests/integration/fileio/test-csv.php
+++ b/tests/integration/fileio/test-csv.php
@@ -79,4 +79,73 @@ class ExportCsvTest extends WP_UnitTestCase {
 
 		$this->assertEquals( '"/source","/target",0,301,"url",0,"","disabled",""', $csv );
 	}
+
+	public function testExportIncludesGroupName() {
+		$exporter = new Red_Csv_File();
+		$item = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source', 'action_data' => '/target', 'action_code' => 301, 'group_id' => 5 ) );
+		$csv = $exporter->item_as_csv( $item, array( 5 => 'My Group' ) );
+
+		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active","My Group"', $csv );
+	}
+
+	public function testExportGroupNameEmptyWhenGroupNotInMap() {
+		$exporter = new Red_Csv_File();
+		$item = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source', 'action_data' => '/target', 'action_code' => 301, 'group_id' => 99 ) );
+		$csv = $exporter->item_as_csv( $item, array( 5 => 'My Group' ) );
+
+		$this->assertEquals( '"/source","/target",0,301,"url",0,"","active",""', $csv );
+	}
+
+	public function testExportMultipleLinesWithGroupNames() {
+		$exporter = new Red_Csv_File();
+		$item1 = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 1, 'regex' => false, 'action_type' => 'url', 'url' => '/source1', 'action_data' => '/target', 'action_code' => 301, 'group_id' => 1 ) );
+		$item2 = new Red_Item( (object) array( 'match_type' => 'url', 'id' => 2, 'regex' => false, 'action_type' => 'url', 'url' => '/source2', 'action_data' => '/target', 'action_code' => 301, 'group_id' => 2 ) );
+		$groups = array(
+			array( 'id' => 1, 'name' => 'Group Alpha' ),
+			array( 'id' => 2, 'name' => 'Group Beta' ),
+		);
+
+		$result = $exporter->get_data( array( $item1, $item2 ), $groups );
+		$lines = array_filter( explode( PHP_EOL, $result ) );
+
+		$this->assertEquals( 3, count( $lines ) );
+		$this->assertEquals( '"/source1","/target",0,301,"url",0,"","active","Group Alpha"', $lines[1] );
+		$this->assertEquals( '"/source2","/target",0,301,"url",0,"","active","Group Beta"', $lines[2] );
+	}
+
+	public function testImportResolvesGroupByName() {
+		$exporter = new Red_Csv_File();
+		$fallback_group = new Red_Group( (object) array( 'id' => 1, 'name' => 'Fallback', 'status' => 'enabled' ) );
+		$groups_by_name = array( 'Target Group' => 42 );
+		$csv = array( '/source', '/target', '0', '301', 'url', '0', '', 'active', 'Target Group' );
+
+		$item = $exporter->csv_as_item( $csv, $fallback_group, $groups_by_name );
+
+		$this->assertNotFalse( $item );
+		$this->assertEquals( 42, $item['group_id'] );
+	}
+
+	public function testImportFallsBackToSelectedGroupWhenNameUnknown() {
+		$exporter = new Red_Csv_File();
+		$fallback_group = new Red_Group( (object) array( 'id' => 1, 'name' => 'Fallback', 'status' => 'enabled' ) );
+		$groups_by_name = array( 'Target Group' => 42 );
+		$csv = array( '/source', '/target', '0', '301', 'url', '0', '', 'active', 'Unknown Group' );
+
+		$item = $exporter->csv_as_item( $csv, $fallback_group, $groups_by_name );
+
+		$this->assertNotFalse( $item );
+		$this->assertEquals( 1, $item['group_id'] );
+	}
+
+	public function testImportFallsBackToSelectedGroupWhenNoGroupColumn() {
+		$exporter = new Red_Csv_File();
+		$fallback_group = new Red_Group( (object) array( 'id' => 1, 'name' => 'Fallback', 'status' => 'enabled' ) );
+		$groups_by_name = array( 'Target Group' => 42 );
+		$csv = array( '/source', '/target', '0', '301' );
+
+		$item = $exporter->csv_as_item( $csv, $fallback_group, $groups_by_name );
+
+		$this->assertNotFalse( $item );
+		$this->assertEquals( 1, $item['group_id'] );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #3946. Also fixes #4106.

Users who export redirects to CSV for bulk editing had no way to preserve or identify which group each redirect belonged to. The exported CSV had no group column, so re-importing after edits would put everything into the group selected in the import UI, losing the original grouping.

### Export

Added a `group` column at the end of the CSV header and rows. The group name is resolved from the `$groups` array already passed to `get_data()`, so no extra DB queries are needed.

Before:
```
source,target,regex,code,type,hits,title,status
"/old","/new",0,301,"url",0,"","active"
```

After:
```
source,target,regex,code,type,hits,title,status,group
"/old","/new",0,301,"url",0,"","active","My Group"
```

### Import

When a group column is present and non-empty, the importer looks it up by name in the existing groups (fetched once with `Red_Group::get_all()`). If found, the redirect is assigned to that group; if not found, it falls back to the group selected in the import UI. Old CSVs without the column import exactly as before.

### Edit action for disabled redirects (fixes #4106)

Removed the `enabled &&` guard from the Edit row action condition in `src/page/redirects/row-actions.tsx`. Previously, the Edit button was hidden for disabled redirects, making them impossible to edit from the list view. The Edit action now appears regardless of enabled/disabled state, matching the expected behaviour.

## Changes

- `fileio/csv.php`: add `CSV_GROUP = 8` constant; populate group name on export; resolve group name on import
- `tests/integration/fileio/test-csv.php`: update expected CSV strings to include the new group column; add tests for export with group names and import group-name resolution
- `src/page/redirects/row-actions.tsx`: show Edit action for disabled redirects

## Test plan

- [ ] Export redirects from multiple groups as CSV — confirm `group` column present with correct names
- [ ] Re-import that CSV — confirm each redirect lands in its original group
- [ ] Import an old CSV (no group column) — confirm it uses the UI-selected group as before
- [ ] Import a CSV with a group name that doesn't exist — confirm it falls back to UI-selected group
- [ ] Disable a redirect and confirm the Edit action is still visible in the row actions