### PR TITLE
Fix missing created time in logs

### DIFF
--- a/src/page/logs/columns.tsx
+++ b/src/page/logs/columns.tsx
@@ -8,6 +8,7 @@ import { RowActions, RowAction } from 'component/table/row-action';
 interface Log {
 	id: number | string;
 	created?: string;
+	created_time?: string;
 	url?: string;
 	sent_to?: string | null;
 	agent?: string | null;
@@ -65,14 +66,27 @@ export function getTarget( row: Log, filterBy: FilterBy ): string | JSX.Element 
 }
 
 export default function getColumns( row: Log, rowParams?: RowParams ): Column[] {
-	const { created, url, agent, referrer, ip, request_method, http_code, domain, redirect_by, count } = row;
+	const { created, created_time, url, agent, referrer, ip, request_method, http_code, domain, redirect_by, count } =
+		row;
 	const filterBy = rowParams?.table?.filterBy || {};
 	const urlSearch = filterBy.url || filterBy[ 'url-exact' ] || '';
 
 	return [
 		{
 			name: 'date',
-			content: created ?? '',
+			content: created ? (
+				<>
+					{ created }
+					{ created_time && (
+						<>
+							<br />
+							{ created_time }
+						</>
+					) }
+				</>
+			) : (
+				''
+			),
 		},
 		{
 			name: 'method',

--- a/src/page/logs404/columns.tsx
+++ b/src/page/logs404/columns.tsx
@@ -8,6 +8,7 @@ import { RowActions, RowAction } from 'component/table/row-action';
 interface Error404 {
 	id: number | string;
 	created?: string;
+	created_time?: string;
 	url?: string;
 	agent?: string;
 	referrer?: string;
@@ -44,14 +45,26 @@ function getUrl( row: Error404 ): string {
 }
 
 export default function getColumns( row: Error404, rowParams?: RowParams ): Column[] {
-	const { created, url, agent, referrer, ip, domain, request_method, http_code, count } = row;
+	const { created, created_time, url, agent, referrer, ip, domain, request_method, http_code, count } = row;
 	const filterBy = rowParams?.table?.filterBy || {};
 	const urlSearch = filterBy.url || filterBy[ 'url-exact' ] || '';
 
 	return [
 		{
 			name: 'date',
-			content: created ?? '',
+			content: created ? (
+				<>
+					{ created }
+					{ created_time && (
+						<>
+							<br />
+							{ created_time }
+						</>
+					) }
+				</>
+			) : (
+				''
+			),
 		},
 		{
 			name: 'method',

--- a/src/types/schemas/log.ts
+++ b/src/types/schemas/log.ts
@@ -12,6 +12,7 @@ import { PaginatedResponseSchema } from './table';
 export const LogSchema = z.object( {
 	id: z.union( [ z.number().int(), z.string() ] ),
 	created: z.string().optional(),
+	created_time: z.string().optional(),
 	url: z.string().optional(),
 	sent_to: z.string().optional().nullable(),
 	agent: z.string().optional().nullable(),


### PR DESCRIPTION
The 404 and redirect logs are missing the time and are just showing the date. Add the time back