### PR TITLE
Don’t run redirect code on CLI usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ svn
 /WARP.md
 /AGENTS.md
 /tsconfig.tsbuildinfo
+.agents
+/CLAUDE.md

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -304,6 +304,13 @@ class WordPress_Module extends Red_Module {
 	 * @return void
 	 */
 	public function canonical_domain() {
+		// In a plain PHP CLI bootstrap (e.g. a cron script that loads wp-load.php)
+		// there is no real HTTP request to redirect. Running die() here would
+		// silently terminate the CLI process before user code can execute.
+		if ( red_is_cli() ) {
+			return;
+		}
+
 		$target = $this->get_canonical_target();
 
 		if ( $target !== false ) {
@@ -320,6 +327,12 @@ class WordPress_Module extends Red_Module {
 	 */
 	public function init() {
 		if ( $this->matched !== false ) {
+			return;
+		}
+
+		// Skip the redirect loop in a plain PHP CLI bootstrap. A matched rule
+		// would call wp_redirect()+die() and silently terminate the CLI process.
+		if ( red_is_cli() ) {
 			return;
 		}
 

--- a/redirection.php
+++ b/redirection.php
@@ -99,6 +99,18 @@ function red_is_wpcli() {
 }
 
 /**
+ * Detect a plain PHP CLI context (e.g., a cron script that loads wp-load.php
+ * directly). Distinct from red_is_wpcli(), which is only true under WP-CLI.
+ * Used to skip front-end redirect enforcement that would otherwise call die()
+ * and silently terminate the CLI process.
+ *
+ * @return bool
+ */
+function red_is_cli() {
+	return PHP_SAPI === 'cli';
+}
+
+/**
  * @return bool
  */
 function red_is_admin() {


### PR DESCRIPTION
Redirects are still processed when used via cron script, causing problems depending on settings. This PR doesn't run the redirect code in those cases