### PR TITLE
fix(site): add optional global lowercase URL redirect

### DIFF
--- a/models/options.php
+++ b/models/options.php
@@ -34,6 +34,7 @@
  *    cache_key: int,
  *    plugin_update: string,
  *    update_notice: int,
+ *    force_lowercase: bool,
  *    flag_query: 'ignore'|'exact'|'pass'|'exactorder',
  *    flag_case: bool,
  *    flag_trailing: bool,
@@ -192,6 +193,7 @@ class Red_Options {
 			'cache_key' => 0,
 			'plugin_update' => 'prompt',
 			'update_notice' => 0,
+			'force_lowercase' => false,
 		];
 
 		$defaults = array_merge( $defaults, $flags->get_json() );
@@ -331,7 +333,7 @@ class Red_Options {
 		}
 
 		// Boolean settings
-		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits' ] as $name ) {
+		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits', 'force_lowercase' ] as $name ) {
 			if ( isset( $settings[ $name ] ) ) {
 				$options[ $name ] = $settings[ $name ] ? true : false;
 			}

--- a/models/url/url-lower.php
+++ b/models/url/url-lower.php
@@ -1,0 +1,110 @@
+<?php
+
+require_once __DIR__ . '/url-path.php';
+
+/**
+ * Global URL lowercase helper.
+ *
+ * When the "force lowercase" option is enabled this builds a canonical target
+ * URL for requests that contain uppercase characters in the path.
+ */
+class Red_Url_Lowercase {
+	/**
+	 * Get a lowercased target URL for a request, or false if no change is needed.
+	 *
+	 * @param string $request_url The current request URL (path + query, e.g. `/Page?x=1`).
+	 * @param string $base_url    The canonical base URL (e.g. `home_url()` or a domain-canonical target).
+	 * @return string|false
+	 */
+	public static function get_target( $request_url, $base_url ) {
+		$request_parts = wp_parse_url( $request_url );
+
+		if ( ! is_array( $request_parts ) || ! isset( $request_parts['path'] ) ) {
+			return false;
+		}
+
+		$path = $request_parts['path'];
+		$lower_path = Red_Url_Path::to_lower( $path );
+
+		// Only redirect when the path actually changes.
+		if ( $lower_path === $path ) {
+			return false;
+		}
+
+		if ( self::is_protected_path( $path ) ) {
+			return false;
+		}
+
+		$base_parts = wp_parse_url( $base_url );
+
+		if ( ! is_array( $base_parts ) ) {
+			return false;
+		}
+
+		return self::build_url( $base_parts, $lower_path, $request_parts['query'] ?? '' );
+	}
+
+	/**
+	 * Should this path be left alone?
+	 *
+	 * @param string $path URL path.
+	 * @return boolean
+	 */
+	private static function is_protected_path( $path ) {
+		$protected = apply_filters(
+			'redirection_lowercase_protected',
+			[ '/wp-admin', '/wp-login.php', '/wp-json/', '/wp-cron.php' ],
+			$path
+		);
+
+		foreach ( $protected as $prefix ) {
+			if ( substr( $path, 0, strlen( $prefix ) ) === $prefix ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build a URL from canonical base parts and a new lowercased path.
+	 *
+	 * @param array<string, mixed> $parts URL parts from wp_parse_url().
+	 * @param string               $path  New path.
+	 * @param string               $query New query string.
+	 * @return string
+	 */
+	private static function build_url( array $parts, $path, $query ) {
+		$url = '';
+
+		if ( isset( $parts['scheme'] ) ) {
+			$url .= $parts['scheme'] . '://';
+		}
+
+		if ( isset( $parts['user'] ) ) {
+			$url .= $parts['user'];
+
+			if ( isset( $parts['pass'] ) ) {
+				$url .= ':' . $parts['pass'];
+			}
+
+			$url .= '@';
+		}
+
+		if ( isset( $parts['host'] ) ) {
+			$url .= $parts['host'];
+		}
+
+		if ( isset( $parts['port'] ) ) {
+			$url .= ':' . $parts['port'];
+		}
+
+		$url .= $path;
+
+		if ( $query !== '' ) {
+			$url .= '?' . $query;
+		}
+
+		return $url;
+	}
+}

--- a/models/url/url.php
+++ b/models/url/url.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/url-flags.php';
 require_once __DIR__ . '/url-request.php';
 require_once __DIR__ . '/url-transform.php';
 require_once __DIR__ . '/url-encode.php';
+require_once __DIR__ . '/url-lower.php';
 
 class Red_Url {
 	/**

--- a/modules/wordpress.php
+++ b/modules/wordpress.php
@@ -291,11 +291,21 @@ class WordPress_Module extends Red_Module {
 
 		// Relocate domain?
 		if ( strlen( $options['relocate'] ) > 0 ) {
-			return $canonical->relocate_request( $options['relocate'], Redirection_Request::get_server_name(), Redirection_Request::get_request_url() );
+			$target = $canonical->relocate_request( $options['relocate'], Redirection_Request::get_server_name(), Redirection_Request::get_request_url() );
+		} else {
+			// Force HTTPS or www
+			$target = $canonical->get_redirect( Redirection_Request::get_request_server_name(), Redirection_Request::get_request_url() );
 		}
 
-		// Force HTTPS or www
-		return $canonical->get_redirect( Redirection_Request::get_request_server_name(), Redirection_Request::get_request_url() );
+		if ( ! empty( $options['force_lowercase'] ) ) {
+			$lowercase = Red_Url_Lowercase::get_target( Redirection_Request::get_request_url(), $target !== false ? $target : home_url() );
+
+			if ( $lowercase !== false ) {
+				$target = $lowercase;
+			}
+		}
+
+		return $target;
 	}
 
 	/**

--- a/src/page/site/canonical/index.tsx
+++ b/src/page/site/canonical/index.tsx
@@ -10,6 +10,7 @@ interface CanonicalSettingsProps {
 	https: boolean;
 	preferredDomain: string;
 	siteDomain: string;
+	forceLowercase: boolean;
 	onChange: ( value: { [ key: string ]: string | boolean } ) => void;
 }
 
@@ -95,12 +96,15 @@ function getCanonical( domain: string, https: boolean, preferred: string ): stri
 	return ( https ? 'https://' : 'http://' ) + domain;
 }
 
-function CanonicalSettings( { https, preferredDomain, siteDomain, onChange }: CanonicalSettingsProps ) {
+function CanonicalSettings( { https, preferredDomain, siteDomain, forceLowercase, onChange }: CanonicalSettingsProps ) {
 	const alert = showAlert( siteDomain, https, preferredDomain );
 	const changePreferred = ( ev: React.ChangeEvent< HTMLInputElement > ) => {
 		onChange( { [ ev.target.name ]: ev.target.value } );
 	};
 	const changeHttps = ( ev: React.ChangeEvent< HTMLInputElement > ) => {
+		onChange( { [ ev.target.name ]: ev.target.checked } );
+	};
+	const changeForceLowercase = ( ev: React.ChangeEvent< HTMLInputElement > ) => {
 		onChange( { [ ev.target.name ]: ev.target.checked } );
 	};
 
@@ -137,6 +141,44 @@ function CanonicalSettings( { https, preferredDomain, siteDomain, onChange }: Ca
 							// translators: %(strong)s is the warning title
 							__(
 								'{{strong}}Warning{{/strong}}: ensure your HTTPS is working before forcing a redirect.',
+								'redirection'
+							),
+							{
+								strong: <strong />,
+							}
+						) }
+					</p>
+				</div>
+			) }
+
+			<p>
+				<input
+					id="canonical-force-lowercase"
+					type="checkbox"
+					name="force_lowercase"
+					onChange={ changeForceLowercase }
+					checked={ forceLowercase }
+				/>
+				&nbsp;
+				<label htmlFor="canonical-force-lowercase">
+					{ createInterpolateElement(
+						__(
+							'Force all URL paths to lowercase - {{code}}/MyPage{{/code}} ⇒ {{code}}/mypage{{/code}}',
+							'redirection'
+						),
+						{
+							code: <code />,
+						}
+					) }
+				</label>
+			</p>
+
+			{ forceLowercase && (
+				<div className="inline-notice inline-warning">
+					<p>
+						{ createInterpolateElement(
+							__(
+								'{{strong}}Warning{{/strong}}: this may break media files with mixed-case filenames.',
 								'redirection'
 							),
 							{

--- a/src/page/site/index.tsx
+++ b/src/page/site/index.tsx
@@ -19,6 +19,7 @@ interface SiteSettings {
 	https?: boolean;
 	aliases?: string[];
 	permalinks?: string[];
+	force_lowercase?: boolean;
 }
 
 export default function Site() {
@@ -36,6 +37,7 @@ export default function Site() {
 	const [ relocate, setRelocate ] = useState< string >( '' );
 	const [ aliases, setAliases ] = useState< string[] >( [] );
 	const [ permalinks, setPermalinks ] = useState< string[] >( [] );
+	const [ forceLowercase, setForceLowercase ] = useState< boolean >( false );
 
 	useEffect( () => {
 		if ( values ) {
@@ -45,6 +47,7 @@ export default function Site() {
 			setRelocate( ( values.relocate || '' ) as string );
 			setAliases( ( values.aliases || [] ) as string[] );
 			setPermalinks( ( values.permalinks || [] ) as string[] );
+			setForceLowercase( values.force_lowercase || false );
 		}
 	}, [ values ] );
 
@@ -57,6 +60,7 @@ export default function Site() {
 			aliases: aliases.filter( ( item ) => item ).map( getDomainOnly ),
 			relocate: getDomainAndPathOnly( relocate ),
 			permalinks,
+			force_lowercase: forceLowercase,
 		} );
 	};
 
@@ -78,6 +82,9 @@ export default function Site() {
 		}
 		if ( settings.permalinks !== undefined ) {
 			setPermalinks( settings.permalinks );
+		}
+		if ( settings.force_lowercase !== undefined ) {
+			setForceLowercase( settings.force_lowercase );
 		}
 	};
 
@@ -110,6 +117,7 @@ export default function Site() {
 					https={ https }
 					siteDomain={ siteDomain as string }
 					preferredDomain={ preferredDomain }
+					forceLowercase={ forceLowercase }
 					onChange={ onChange }
 				/>
 			) }

--- a/src/types/schemas/settings.ts
+++ b/src/types/schemas/settings.ts
@@ -19,6 +19,7 @@ export const SettingsSchema = z
 		rest_api: z.number().int().optional(),
 		https: z.boolean().optional(),
 		headers: z.array( z.unknown() ).optional(),
+		force_lowercase: z.boolean().optional(),
 		flag_regex: z.boolean().optional(),
 		flag_query: z.string().optional(),
 		flag_trailing: z.boolean().optional(),

--- a/tests/unit/test-url-lower.php
+++ b/tests/unit/test-url-lower.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once PLUGIN_PATH . '/models/url/url-path.php';
+require_once PLUGIN_PATH . '/models/url/url-lower.php';
+
+use Brain\Monkey\Functions;
+
+class UrlLowerTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\expect( 'apply_filters' )
+			->andReturnUsing(
+				function ( $tag, $value ) {
+					return $value;
+				}
+			);
+	}
+
+	public function testNoChange() {
+		$this->assertFalse( Red_Url_Lowercase::get_target( '/already-lower', 'https://example.org' ) );
+	}
+
+	public function testUppercasePath() {
+		$this->assertEquals( 'https://example.org/mypage', Red_Url_Lowercase::get_target( '/MyPage', 'https://example.org' ) );
+	}
+
+	public function testPreservesQuery() {
+		$this->assertEquals( 'https://example.org/mypage?x=1', Red_Url_Lowercase::get_target( '/MyPage?x=1', 'https://example.org' ) );
+	}
+
+	public function testProtectedPath() {
+		$this->assertFalse( Red_Url_Lowercase::get_target( '/wp-admin/Settings', 'https://example.org' ) );
+	}
+
+	public function testProtectedLogin() {
+		$this->assertFalse( Red_Url_Lowercase::get_target( '/wp-login.php', 'https://example.org' ) );
+	}
+
+	public function testProtectedRest() {
+		$this->assertFalse( Red_Url_Lowercase::get_target( '/wp-json/wp/v2/posts', 'https://example.org' ) );
+	}
+
+	public function testCanonicalTargetBase() {
+		$this->assertEquals( 'https://www.example.org/mypage', Red_Url_Lowercase::get_target( '/MyPage', 'https://www.example.org/MyPage' ) );
+	}
+
+	public function testSubdirectory() {
+		$this->assertEquals( 'https://example.org/wp/mypage', Red_Url_Lowercase::get_target( '/wp/MyPage', 'https://example.org/wp' ) );
+	}
+
+	public function testUtf8Path() {
+		$this->assertEquals( 'https://example.org/café', Red_Url_Lowercase::get_target( '/Café', 'https://example.org' ) );
+	}
+}


### PR DESCRIPTION
## Summary
Adds a new "Force all URL paths to lowercase" option in Redirection > Site > Canonical Settings. When enabled, mixed-case request paths get a 301 redirect to their lowercase version before the main redirect loop runs, preserving the query string and avoiding redirect loops.

Fixes #4185

## Changes
### models/options.php
Added `force_lowercase` to option defaults and the boolean sanitization loop.

### models/url/url-lower.php
**New helper.** `Red_Url_Lowercase::get_target()` parses the request path, lowercases it with `Red_Url_Path::to_lower()`, and rebuilds the target URL using the canonical base. It only redirects when the path actually changes, and it skips `/wp-admin`, `/wp-login.php`, `/wp-json/`, and `/wp-cron.php`.

### modules/wordpress.php
After the existing canonical target is computed, if `force_lowercase` is enabled the lowercased path target is applied.

### Site settings UI
Added a checkbox in `src/page/site/canonical/index.tsx` with a warning that mixed-case media filenames may break.

### Tests
Added `tests/unit/test-url-lower.php` covering no-change, uppercase paths, query preservation, protected paths, and canonical base targets.

## Testing
- `composer test-unit` passes.
- `pnpm test:js` passes.
- `composer lint` and `composer analyse` (PHPStan level 8) pass.
- `pnpm lint:ts` passes.

**Manual test:**
1. Enable the option in Redirection > Site.
2. Visit `/MyPage`.
3. Result: 301 redirect to `/mypage`.

## Screenshots
<img width="1910" height="790" alt="image" src="https://github.com/user-attachments/assets/4ec1c019-1e59-4317-8c48-07560d2256cc" />

---

<img width="1748" height="363" alt="image" src="https://github.com/user-attachments/assets/d223d32e-d109-42d6-8f52-4a0daa9516d2" />
