### PR TITLE
feat(monitor): keep domain in generated redirects for multilingual sites

### DIFF
--- a/models/monitor.php
+++ b/models/monitor.php
@@ -22,6 +22,11 @@ class Red_Monitor {
 	private $associated = '';
 
 	/**
+	 * @var bool
+	 */
+	private $monitor_keep_domain = false;
+
+	/**
 	 * @param array<string, mixed> $options
 	 */
 	public function __construct( array $options ) {
@@ -30,6 +35,7 @@ class Red_Monitor {
 		if ( count( $this->monitor_types ) > 0 && $options['monitor_post'] > 0 ) {
 			$this->monitor_group_id = intval( $options['monitor_post'], 10 );
 			$this->associated = isset( $options['associated_redirect'] ) ? $options['associated_redirect'] : '';
+			$this->monitor_keep_domain = isset( $options['monitor_keep_domain'] ) ? (bool) $options['monitor_keep_domain'] : false;
 
 			// Only monitor if permalinks enabled
 			if ( get_option( 'permalink_structure' ) !== false ) {
@@ -206,8 +212,14 @@ class Red_Monitor {
 			return false;
 		}
 
-		$after = wp_parse_url( $permalink, PHP_URL_PATH );
-		$before = wp_parse_url( esc_url( $before ), PHP_URL_PATH );
+		$after_url = wp_parse_url( $permalink );
+		$after = isset( $after_url['path'] ) ? $after_url['path'] : null;
+		$after_host = isset( $after_url['host'] ) ? $after_url['host'] : null;
+		$after_scheme = isset( $after_url['scheme'] ) ? $after_url['scheme'] : ( is_ssl() ? 'https' : 'http' );
+
+		$before_url = wp_parse_url( esc_url( $before ) );
+		$before = isset( $before_url['path'] ) ? $before_url['path'] : null;
+		$before_host = isset( $before_url['host'] ) ? $before_url['host'] : null;
 
 		if ( is_string( $before ) && is_string( $after ) && apply_filters( 'redirection_permalink_changed', false, $before, $after ) ) {
 			do_action( 'redirection_remove_existing', $after, $post_id );
@@ -221,6 +233,20 @@ class Red_Monitor {
 				'group_id'    => $this->monitor_group_id,
 			);
 
+			if ( $this->monitor_keep_domain && is_string( $after_host ) && $after_host !== '' && is_string( $before_host ) && $after_host !== $before_host ) {
+				$data = $this->add_domain_match( $data, $after_scheme, $after_host, $after );
+			}
+
+			/**
+			 * Filter the redirect data before creating a redirect for a modified post slug.
+			 *
+			 * @param array  $data    The redirect data to be created.
+			 * @param int    $post_id The ID of the modified post.
+			 * @param string $before  The previous URL path.
+			 * @param string $after   The new URL path.
+			 */
+			$data = apply_filters( 'redirection_monitor_data', $data, $post_id, $before, $after );
+
 			// Create a new redirect for this post
 			$new_item = Red_Item::create( $data );
 
@@ -230,7 +256,12 @@ class Red_Monitor {
 				if ( ! empty( $this->associated ) ) {
 					// Create an associated redirect for this post
 					$data['url'] = trailingslashit( $data['url'] ) . ltrim( $this->associated, '/' );
-					$data['action_data'] = array( 'url' => trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' ) );
+					if ( isset( $data['action_data']['url'] ) ) {
+						$data['action_data']['url'] = trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' );
+					}
+					if ( isset( $data['action_data']['url_from'] ) ) {
+						$data['action_data']['url_from'] = trailingslashit( $data['action_data']['url_from'] ) . ltrim( $this->associated, '/' );
+					}
 					Red_Item::create( $data );
 				}
 			}
@@ -239,5 +270,24 @@ class Red_Monitor {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Convert redirect data into a URL and server match scoped to the given domain.
+	 *
+	 * @param array<string, mixed> $data    Redirect data.
+	 * @param string               $scheme  URL scheme.
+	 * @param string               $host    Server host.
+	 * @param string               $target  Target URL path.
+	 * @return array<string, mixed>
+	 */
+	private function add_domain_match( array $data, string $scheme, string $host, string $target ): array {
+		$data['match_type'] = 'server';
+		$data['action_data'] = array(
+			'server'   => $scheme . '://' . $host,
+			'url_from' => $target,
+		);
+
+		return $data;
 	}
 }

--- a/models/options.php
+++ b/models/options.php
@@ -11,6 +11,7 @@
  *    monitor_post: int,
  *    monitor_types: array<string>,
  *    associated_redirect: string,
+ *    monitor_keep_domain: bool,
  *    auto_target: string,
  *    expire_redirect: int,
  *    expire_404: int,
@@ -169,6 +170,7 @@ class Red_Options {
 			'monitor_post' => 0,
 			'monitor_types' => [],
 			'associated_redirect' => '',
+			'monitor_keep_domain' => false,
 			'auto_target' => '',
 			'expire_redirect' => 7,
 			'expire_404' => 7,
@@ -295,6 +297,7 @@ class Red_Options {
 		if ( isset( $settings['monitor_types'] ) && count( $monitor_types ) === 0 ) {
 			$options['monitor_post'] = 0;
 			$options['associated_redirect'] = '';
+			$options['monitor_keep_domain'] = false;
 		} elseif ( isset( $settings['monitor_post'] ) ) {
 			$options['monitor_post'] = max( 0, intval( $settings['monitor_post'], 10 ) );
 
@@ -331,7 +334,7 @@ class Red_Options {
 		}
 
 		// Boolean settings
-		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits' ] as $name ) {
+		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits', 'monitor_keep_domain' ] as $name ) {
 			if ( isset( $settings[ $name ] ) ) {
 				$options[ $name ] = $settings[ $name ] ? true : false;
 			}

--- a/src/page/options/options-form/url-monitor.tsx
+++ b/src/page/options/options-form/url-monitor.tsx
@@ -15,6 +15,7 @@ interface Settings {
 	associated_redirect: string;
 	monitor_post: number;
 	monitor_types: string[];
+	monitor_keep_domain: boolean;
 }
 
 interface UrlMonitoringProps {
@@ -83,7 +84,7 @@ function getMonitorPost( post: number, groups: GroupOption[] ): number {
 
 function UrlMonitoring( props: UrlMonitoringProps ) {
 	const { onChange, settings, groups, getLink, postTypes } = props;
-	const { associated_redirect, monitor_post, monitor_types } = settings;
+	const { associated_redirect, monitor_post, monitor_types, monitor_keep_domain } = settings;
 	const canMonitor = monitor_types.length > 0;
 
 	function onChangeMonitor( ev: React.ChangeEvent< HTMLInputElement > ) {
@@ -98,8 +99,10 @@ function UrlMonitoring( props: UrlMonitoringProps ) {
 			monitor_types: filteredTypes,
 			monitor_post: filteredTypes.length > 0 ? getMonitorPost( monitor_post, groups ) : 0,
 			associated_redirect: filteredTypes.length > 0 ? associated_redirect : '',
+			monitor_keep_domain: filteredTypes.length > 0 ? monitor_keep_domain : false,
 		} );
 	}
+
 
 	return (
 		<>
@@ -131,6 +134,18 @@ function UrlMonitoring( props: UrlMonitoringProps ) {
 						/>
 						&nbsp;
 						{ __( 'Create associated redirect (added to end of URL)', 'redirection' ) }
+					</p>
+					<p>
+						<input
+							id="monitor-keep-domain"
+							type="checkbox"
+							name="monitor_keep_domain"
+							onChange={ onChange as any }
+							checked={ monitor_keep_domain }
+						/>
+						<label htmlFor="monitor-keep-domain">
+							{ __( 'Keep domain in generated redirect', 'redirection' ) }
+						</label>
 					</p>
 				</TableRow>
 			) }

--- a/src/page/options/options-form/url-options.tsx
+++ b/src/page/options/options-form/url-options.tsx
@@ -18,6 +18,7 @@ interface Settings {
 	associated_redirect: string;
 	monitor_post: number;
 	monitor_types: string[];
+	monitor_keep_domain: boolean;
 }
 
 interface GroupOption {

--- a/src/types/schemas/settings.ts
+++ b/src/types/schemas/settings.ts
@@ -15,6 +15,7 @@ export const SettingsSchema = z
 		monitor_post: z.number().int().optional(),
 		monitor_types: z.array( z.string() ).optional(),
 		associated_redirect: z.string().optional(),
+		monitor_keep_domain: z.boolean().optional(),
 		redirect_cache: z.number().int().optional(),
 		rest_api: z.number().int().optional(),
 		https: z.boolean().optional(),

--- a/tests/integration/models/test-monitor.php
+++ b/tests/integration/models/test-monitor.php
@@ -377,4 +377,100 @@ class MonitorTest extends WP_UnitTestCase {
 		$this->assertEquals( $url, $args[0][1] );
 		$this->assertEquals( $post, $args[0][2] );
 	}
+
+	public function testKeepDomainFalseCreatesUrlMatch() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( [
+			'monitor_post' => $this->group->get_id(),
+			'monitor_types' => [ 'post' ],
+			'associated_redirect' => '',
+			'monitor_keep_domain' => false,
+		] );
+		$before = parse_url( get_permalink( $this->post_id ), PHP_URL_PATH );
+		$this->factory->post->update_object( $this->post_id, array( 'post_name' => 'something' ) );
+		$after = parse_url( get_permalink( $this->post_id ), PHP_URL_PATH );
+
+		$this->assertTrue( $monitor->check_for_modified_slug( $this->post_id, $before ) );
+
+		$redirect = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 1" );
+		$this->assertEquals( $before, $redirect->url );
+		$this->assertEquals( 'url', $redirect->match_type );
+		$this->assertEquals( $after, $redirect->action_data );
+	}
+
+	public function testKeepDomainTrueCreatesServerMatch() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( [
+			'monitor_post' => $this->group->get_id(),
+			'monitor_types' => [ 'post' ],
+			'associated_redirect' => '',
+			'monitor_keep_domain' => true,
+		] );
+		$before = get_permalink( $this->post_id );
+
+		// Simulate Polylang/WPML domain-per-language by changing the home URL for this request.
+		add_filter( 'pre_option_home', function() {
+			return 'http://example.nl';
+		} );
+		$this->factory->post->update_object( $this->post_id, array( 'post_name' => 'something' ) );
+		$after = get_permalink( $this->post_id );
+		$after_path = parse_url( $after, PHP_URL_PATH );
+
+		$this->assertEquals( 'example.nl', parse_url( $after, PHP_URL_HOST ) );
+		$this->assertTrue( $monitor->check_for_modified_slug( $this->post_id, $before ) );
+
+		$redirect = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 1" );
+		$this->assertEquals( parse_url( $before, PHP_URL_PATH ), $redirect->url );
+		$this->assertEquals( 'server', $redirect->match_type );
+
+		$action_data = maybe_unserialize( $redirect->action_data );
+		$this->assertEquals( 'http://example.nl', $action_data['server'] );
+		$this->assertEquals( $after_path, $action_data['url_from'] );
+	}
+
+	public function testKeepDomainTrueSameHostCreatesUrlMatch() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( [
+			'monitor_post' => $this->group->get_id(),
+			'monitor_types' => [ 'post' ],
+			'associated_redirect' => '',
+			'monitor_keep_domain' => true,
+		] );
+		$before = get_permalink( $this->post_id );
+		$this->factory->post->update_object( $this->post_id, array( 'post_name' => 'something' ) );
+		$after = get_permalink( $this->post_id );
+
+		$this->assertTrue( $monitor->check_for_modified_slug( $this->post_id, $before ) );
+
+		$redirect = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 1" );
+		$this->assertEquals( parse_url( $before, PHP_URL_PATH ), $redirect->url );
+		$this->assertEquals( 'url', $redirect->match_type );
+		$this->assertEquals( parse_url( $after, PHP_URL_PATH ), $redirect->action_data );
+	}
+
+	public function testMonitorDataFilterCanModifyRedirect() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( [
+			'monitor_post' => $this->group->get_id(),
+			'monitor_types' => [ 'post' ],
+			'associated_redirect' => '',
+			'monitor_keep_domain' => false,
+		] );
+		$before = parse_url( get_permalink( $this->post_id ), PHP_URL_PATH );
+		$this->factory->post->update_object( $this->post_id, array( 'post_name' => 'something' ) );
+
+		add_filter( 'redirection_monitor_data', function( $data, $post_id, $before, $after ) {
+			$data['action_code'] = 302;
+			return $data;
+		}, 10, 4 );
+
+		$this->assertTrue( $monitor->check_for_modified_slug( $this->post_id, $before ) );
+
+		$redirect = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 1" );
+		$this->assertEquals( 302, $redirect->action_code );
+	}
 }


### PR DESCRIPTION
## Summary

When using Polylang or WPML with separate domains per language, the URL Monitor currently creates plain URL redirects that fire on every domain. This change adds a `Keep domain in generated redirect` option. When enabled, monitored post slug changes automatically create a `URL and server` match so the redirect only applies on the domain the post belongs to. A `redirection_monitor_data` filter is also added for integrations that need custom behavior.

Fixes #4168

## Changes

### `models/monitor.php`

**Before:**
```php
$after = wp_parse_url( $permalink, PHP_URL_PATH );
$before = wp_parse_url( esc_url( $before ), PHP_URL_PATH );
```

**After:**
```php
$after_url = wp_parse_url( $permalink );
$after = isset( $after_url['path'] ) ? $after_url['path'] : null;
$after_host = isset( $after_url['host'] ) ? $after_url['host'] : null;
$after_scheme = isset( $after_url['scheme'] ) ? $after_url['scheme'] : ( is_ssl() ? 'https' : 'http' );

$before_url = wp_parse_url( esc_url( $before ) );
$before = isset( $before_url['path'] ) ? $before_url['path'] : null;
$before_host = isset( $before_url['host'] ) ? $before_url['host'] : null;
```

**Why:** `get_permalink()` already returns the language-specific URL, including the domain. We now keep the host so we can build a `URL and server` match when the option is on and the post's domain changed.

### `models/options.php`

**Before:** options only had `monitor_post`, `monitor_types`, and `associated_redirect`.

**After:** added `monitor_keep_domain` defaulting to `false`, saved as a boolean, and cleared when URL monitoring is disabled.

**Why:** keeps the feature opt-in and backward compatible. Existing installs keep the old behavior until they turn it on.

### `src/page/options/options-form/url-monitor.tsx`

**After:** a checkbox labeled `Keep domain in generated redirect` is shown when at least one post type is monitored.

**Why:** gives users a visible, easy toggle without needing a custom snippet or filter.

### `tests/integration/models/test-monitor.php`

**After:** added tests for default `url` match, `server` match when domains differ, same-host `url` match, and the new `redirection_monitor_data` filter.

**Why:** covers the new behavior, the no-op subdirectory case, and the filter hook.

## Testing

**Test 1: Polylang domain-per-language**
1. Configure Polylang with English on `domain.com` and Dutch on `domain.nl`.
2. In Redirection > Options > URL Monitor, enable post monitoring, pick a group, and check `Keep domain in generated redirect`.
3. Change a Dutch post slug.
4. Result: a `URL and server` redirect is created with server `domain.nl` and target URL on `domain.nl`. Only fires on the Dutch domain.

**Test 2: Same host (subdirectory mode)**
1. Use Polylang in subdirectory mode (`domain.com/en/` and `domain.com/nl/`).
2. Enable the option and change a slug.
3. Result: a plain `URL` redirect is created because the host did not change. No-op and safe.

**Test 3: Backward compatibility**
1. Leave the option off (default).
2. Change a slug.
3. Result: a plain `URL` redirect is created, same as before.

**Automated tests:**
- `composer test-unit` — pass (109 tests)
- `composer run-script checks` — PHPCS + PHPStan level 8 pass
- `pnpm lint:ts` — pass
- `pnpm test:js` — pass (240 tests)
- Monitor integration tests — pass (29 tests)