### PR TITLE
fix(monitor): add option to redirect child pages when parent slug changes

### DIFF
--- a/models/monitor.php
+++ b/models/monitor.php
@@ -22,6 +22,11 @@ class Red_Monitor {
 	private $associated = '';
 
 	/**
+	 * @var bool
+	 */
+	private $monitor_children = false;
+
+	/**
 	 * @param array<string, mixed> $options
 	 */
 	public function __construct( array $options ) {
@@ -30,6 +35,7 @@ class Red_Monitor {
 		if ( count( $this->monitor_types ) > 0 && $options['monitor_post'] > 0 ) {
 			$this->monitor_group_id = intval( $options['monitor_post'], 10 );
 			$this->associated = isset( $options['associated_redirect'] ) ? $options['associated_redirect'] : '';
+			$this->monitor_children = ! empty( $options['monitor_children'] );
 
 			// Only monitor if permalinks enabled
 			if ( get_option( 'permalink_structure' ) !== false ) {
@@ -209,35 +215,103 @@ class Red_Monitor {
 		$after = wp_parse_url( $permalink, PHP_URL_PATH );
 		$before = wp_parse_url( esc_url( $before ), PHP_URL_PATH );
 
-		if ( is_string( $before ) && is_string( $after ) && apply_filters( 'redirection_permalink_changed', false, $before, $after ) ) {
-			do_action( 'redirection_remove_existing', $after, $post_id );
-
-			$data = array(
-				'url'         => $before,
-				'action_data' => array( 'url' => $after ),
-				'match_type'  => 'url',
-				'action_type' => 'url',
-				'action_code' => 301,
-				'group_id'    => $this->monitor_group_id,
-			);
-
-			// Create a new redirect for this post
-			$new_item = Red_Item::create( $data );
-
-			if ( ! is_wp_error( $new_item ) ) {
-				do_action( 'redirection_monitor_created', $new_item, $before, $post_id );
-
-				if ( ! empty( $this->associated ) ) {
-					// Create an associated redirect for this post
-					$data['url'] = trailingslashit( $data['url'] ) . ltrim( $this->associated, '/' );
-					$data['action_data'] = array( 'url' => trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' ) );
-					Red_Item::create( $data );
-				}
-			}
-
-			return true;
+		if ( ! is_string( $before ) || ! is_string( $after ) || ! apply_filters( 'redirection_permalink_changed', false, $before, $after ) ) {
+			return false;
 		}
 
-		return false;
+		$created = $this->create_redirect( $post_id, $before, $after );
+
+		$post_type = get_post_type( $post_id );
+		if ( $created && $this->monitor_children && is_string( $post_type ) && is_post_type_hierarchical( $post_type ) ) {
+			$this->create_children_redirects( $post_id, $before, $after );
+		}
+
+		return $created;
+	}
+
+	/**
+	 * Create a monitor redirect for a post id from before to after.
+	 *
+	 * @param int $post_id
+	 * @param string $before
+	 * @param string $after
+	 * @return bool
+	 */
+	private function create_redirect( int $post_id, string $before, string $after ): bool {
+		do_action( 'redirection_remove_existing', $after, $post_id );
+
+		$data = array(
+			'url'         => $before,
+			'action_data' => array( 'url' => $after ),
+			'match_type'  => 'url',
+			'action_type' => 'url',
+			'action_code' => 301,
+			'group_id'    => $this->monitor_group_id,
+		);
+
+		$new_item = Red_Item::create( $data );
+
+		if ( is_wp_error( $new_item ) ) {
+			return false;
+		}
+
+		do_action( 'redirection_monitor_created', $new_item, $before, $post_id );
+
+		if ( ! empty( $this->associated ) ) {
+			$data['url'] = trailingslashit( $data['url'] ) . ltrim( $this->associated, '/' );
+			$data['action_data'] = array( 'url' => trailingslashit( $data['action_data']['url'] ) . ltrim( $this->associated, '/' ) );
+			Red_Item::create( $data );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create redirects for descendant pages when a hierarchical parent slug changes.
+	 *
+	 * @param int $post_id
+	 * @param string $before
+	 * @param string $after
+	 * @return void
+	 */
+	private function create_children_redirects( int $post_id, string $before, string $after ): void {
+		$post_type = get_post_type( $post_id );
+		if ( $post_type === false || ! is_post_type_hierarchical( $post_type ) ) {
+			return;
+		}
+
+		$descendants = get_pages(
+			array(
+				'child_of'    => $post_id,
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+			)
+		);
+
+		if ( ! is_array( $descendants ) || count( $descendants ) === 0 ) {
+			return;
+		}
+
+		$old_prefix = trailingslashit( $before );
+		$new_prefix = trailingslashit( $after );
+
+		foreach ( $descendants as $child ) {
+			$child_permalink = get_permalink( $child->ID );
+			if ( $child_permalink === false ) {
+				continue;
+			}
+
+			$child_after = wp_parse_url( $child_permalink, PHP_URL_PATH );
+			if ( ! is_string( $child_after ) || strpos( $child_after, $new_prefix ) !== 0 ) {
+				continue;
+			}
+
+			$child_before = $old_prefix . substr( $child_after, strlen( $new_prefix ) );
+			if ( $child_before === $child_after ) {
+				continue;
+			}
+
+			$this->create_redirect( $child->ID, $child_before, $child_after );
+		}
 	}
 }

--- a/models/options.php
+++ b/models/options.php
@@ -39,7 +39,8 @@
  *    flag_trailing: bool,
  *    flag_regex: bool,
  *    database_stage?: array{stage?: string|false, stages?: array<mixed>, status?: string|false},
- *    location?: string
+ *    location?: string,
+ *    monitor_children: bool
  * }
  */
 class Red_Options {
@@ -168,6 +169,7 @@ class Red_Options {
 			'token' => md5( uniqid() ),
 			'monitor_post' => 0,
 			'monitor_types' => [],
+			'monitor_children' => false,
 			'associated_redirect' => '',
 			'auto_target' => '',
 			'expire_redirect' => 7,
@@ -331,7 +333,7 @@ class Red_Options {
 		}
 
 		// Boolean settings
-		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits' ] as $name ) {
+		foreach ( [ 'support', 'https', 'log_external', 'log_header', 'track_hits', 'monitor_children' ] as $name ) {
 			if ( isset( $settings[ $name ] ) ) {
 				$options[ $name ] = $settings[ $name ] ? true : false;
 			}
@@ -368,6 +370,7 @@ class Red_Options {
 		if ( ! empty( $options['monitor_post'] ) && count( $options['monitor_types'] ) === 0 ) {
 			// If we have a monitor_post set, but no types, then blank everything
 			$options['monitor_post'] = 0;
+			$options['monitor_children'] = false;
 			$options['associated_redirect'] = '';
 		}
 

--- a/src/page/options/options-form/url-monitor.tsx
+++ b/src/page/options/options-form/url-monitor.tsx
@@ -15,6 +15,7 @@ interface Settings {
 	associated_redirect: string;
 	monitor_post: number;
 	monitor_types: string[];
+	monitor_children?: boolean;
 }
 
 interface UrlMonitoringProps {
@@ -83,7 +84,7 @@ function getMonitorPost( post: number, groups: GroupOption[] ): number {
 
 function UrlMonitoring( props: UrlMonitoringProps ) {
 	const { onChange, settings, groups, getLink, postTypes } = props;
-	const { associated_redirect, monitor_post, monitor_types } = settings;
+	const { associated_redirect, monitor_post, monitor_types, monitor_children } = settings;
 	const canMonitor = monitor_types.length > 0;
 
 	function onChangeMonitor( ev: React.ChangeEvent< HTMLInputElement > ) {
@@ -131,6 +132,18 @@ function UrlMonitoring( props: UrlMonitoringProps ) {
 						/>
 						&nbsp;
 						{ __( 'Create associated redirect (added to end of URL)', 'redirection' ) }
+					</p>
+					<p>
+						<input
+							id="monitor-children"
+							type="checkbox"
+							name="monitor_children"
+							onChange={ onChange as any }
+							checked={ !! monitor_children }
+						/>
+						<label htmlFor="monitor-children">
+							{ __( 'Create redirects for child pages when a parent slug changes', 'redirection' ) }
+						</label>
 					</p>
 				</TableRow>
 			) }

--- a/src/types/schemas/settings.ts
+++ b/src/types/schemas/settings.ts
@@ -14,6 +14,7 @@ export const SettingsSchema = z
 		location: z.string().optional(),
 		monitor_post: z.number().int().optional(),
 		monitor_types: z.array( z.string() ).optional(),
+		monitor_children: z.boolean().optional(),
 		associated_redirect: z.string().optional(),
 		redirect_cache: z.number().int().optional(),
 		rest_api: z.number().int().optional(),

--- a/tests/integration/models/test-monitor.php
+++ b/tests/integration/models/test-monitor.php
@@ -33,11 +33,12 @@ class MonitorTest extends WP_UnitTestCase {
 		);
 	}
 
-	private function getActiveOptions( $group_id = 1, $types = 'post', $associated = '' ) {
+	private function getActiveOptions( $group_id = 1, $types = 'post', $associated = '', $monitor_children = false ) {
 		return array(
 			'monitor_post' => $group_id,
 			'monitor_types' => array( $types ),
 			'associated_redirect' => $associated,
+			'monitor_children' => $monitor_children,
 		);
 	}
 
@@ -376,5 +377,116 @@ class MonitorTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'Red_Item', $args[0][0] );
 		$this->assertEquals( $url, $args[0][1] );
 		$this->assertEquals( $post, $args[0][2] );
+	}
+
+	public function testChildRedirectsCreatedWhenEnabled() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions( $this->group->get_id(), 'page', '', true ) );
+		$parent = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Parent', 'post_name' => 'parent' ) );
+		$child = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Child', 'post_name' => 'child', 'post_parent' => $parent ) );
+		$before_parent = parse_url( get_permalink( $parent ), PHP_URL_PATH );
+		$before_child = parse_url( get_permalink( $child ), PHP_URL_PATH );
+		$total = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+
+		$this->factory->post->update_object( $parent, array( 'post_name' => 'renamed' ) );
+		$after_child = parse_url( get_permalink( $child ), PHP_URL_PATH );
+
+		$after = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+		$this->assertEquals( $total + 2, $after );
+
+		$redirects = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 2" );
+		$parent_redirect = $redirects[1];
+		$child_redirect = $redirects[0];
+
+		$this->assertEquals( $before_parent, $parent_redirect->url );
+		$this->assertEquals( '/renamed/', $parent_redirect->action_data );
+		$this->assertEquals( $before_child, $child_redirect->url );
+		$this->assertEquals( $after_child, $child_redirect->action_data );
+	}
+
+	public function testChildRedirectsNotCreatedWhenDisabled() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions( $this->group->get_id(), 'page', '', false ) );
+		$parent = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Parent', 'post_name' => 'parent' ) );
+		$child = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Child', 'post_name' => 'child', 'post_parent' => $parent ) );
+		$total = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+
+		$this->factory->post->update_object( $parent, array( 'post_name' => 'renamed' ) );
+
+		$after = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+		$this->assertEquals( $total + 1, $after );
+	}
+
+	public function testNonHierarchicalChildrenIgnored() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions( $this->group->get_id(), 'post', '', true ) );
+		$post = $this->factory->post->create( array( 'post_title' => 'Post', 'post_name' => 'post' ) );
+		$total = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+
+		$this->factory->post->update_object( $post, array( 'post_name' => 'renamed' ) );
+
+		$after = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+		$this->assertEquals( $total + 1, $after );
+	}
+
+	public function testGrandchildRedirectsCreated() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions( $this->group->get_id(), 'page', '', true ) );
+		$parent = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Parent', 'post_name' => 'parent' ) );
+		$child = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Child', 'post_name' => 'child', 'post_parent' => $parent ) );
+		$grandchild = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Grandchild', 'post_name' => 'grandchild', 'post_parent' => $child ) );
+		$before_parent = parse_url( get_permalink( $parent ), PHP_URL_PATH );
+		$before_child = parse_url( get_permalink( $child ), PHP_URL_PATH );
+		$before_grandchild = parse_url( get_permalink( $grandchild ), PHP_URL_PATH );
+		$total = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+
+		$this->factory->post->update_object( $parent, array( 'post_name' => 'renamed' ) );
+		$after_child = parse_url( get_permalink( $child ), PHP_URL_PATH );
+		$after_grandchild = parse_url( get_permalink( $grandchild ), PHP_URL_PATH );
+
+		$after = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+		$this->assertEquals( $total + 3, $after );
+
+		$redirects = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}redirection_items ORDER BY id DESC LIMIT 3" );
+		$parent_redirect = $redirects[2];
+		$child_redirect = $redirects[1];
+		$grandchild_redirect = $redirects[0];
+
+		$this->assertEquals( $before_parent, $parent_redirect->url );
+		$this->assertEquals( '/renamed/', $parent_redirect->action_data );
+		$this->assertEquals( $before_child, $child_redirect->url );
+		$this->assertEquals( $after_child, $child_redirect->action_data );
+		$this->assertEquals( $before_grandchild, $grandchild_redirect->url );
+		$this->assertEquals( $after_grandchild, $grandchild_redirect->action_data );
+	}
+
+	public function testChildExistingRedirectDisabled() {
+		global $wpdb;
+
+		$monitor = new Red_Monitor( $this->getActiveOptions( $this->group->get_id(), 'page', '', true ) );
+		$parent = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Parent', 'post_name' => 'parent' ) );
+		$child = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Child', 'post_name' => 'child', 'post_parent' => $parent ) );
+		$total = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+
+		Red_Item::create( array(
+			'url' => '/renamed/child/',
+			'action_data' => array( 'url' => '/somewhere/' ),
+			'match_type' => 'url',
+			'action_type' => 'url',
+			'action_code' => 301,
+			'group_id' => $this->group->get_id(),
+		) );
+
+		$this->factory->post->update_object( $parent, array( 'post_name' => 'renamed' ) );
+
+		$after = intval( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items" ), 10 );
+		$this->assertEquals( $total + 3, $after );
+
+		$existing = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}redirection_items WHERE url = '/renamed/child/' ORDER BY id ASC LIMIT 1" );
+		$this->assertEquals( 'disabled', $existing->status );
 	}
 }


### PR DESCRIPTION
## Summary

When a parent page slug is changed, WordPress also changes the URLs of all child and grandchild pages. This PR adds a new opt-in setting `monitor_children` that creates 301 redirects for every descendant page when the parent is renamed. Existing behavior is unchanged by default.

Fixes #4208

## Changes

### `models/options.php`

**Before:** no option for child redirects.

**After:**

```php
'monitor_children' => false,
```

Added to defaults, the boolean sanitization loop, and the PHPDoc options shape.

**Why:** keeps the new setting centralized and filterable through the existing options system.

### `models/monitor.php`

**Before:** `check_for_modified_slug()` created only the parent redirect.

**After:** the redirect creation block is refactored into a private `create_redirect()` helper, and `check_for_modified_slug()` calls a new `create_children_redirects()` method when the option is enabled and the post type is hierarchical.

**Why:** reuses the same group, 301 action, `redirection_remove_existing`, `redirection_monitor_created`, and associated-redirect logic for all descendants without duplicating code.

### URL Monitor UI and settings schema

**After:** added a checkbox in `src/page/options/options-form/url-monitor.tsx` and `monitor_children` to `src/types/schemas/settings.ts`.

**Why:** lets users opt in from the existing options page.

### `tests/integration/models/test-monitor.php`

**After:** added tests covering child redirects when enabled, disabled behavior, non-hierarchical post types, grandchildren, and disabling an existing redirect that matches the new child URL.

**Why:** covers the main behavior and edge cases.

## Testing

**Automated tests**
- `composer test-unit` — 109 tests passed
- `pnpm test:integration` — 616 tests passed
- `composer lint` — passed
- `composer analyse` — PHPStan level 8 passed
- `pnpm lint:ts` — passed
- `pnpm test:js` — 240 tests passed

**Manual test**
1. Enable page monitoring and check "Create redirects for child pages when a parent slug changes".
2. Create `parent` page, `child` page under it, `grandchild` page under child.
3. Rename `parent` to `renamed-parent`.
4. Result: redirects created for `/parent/`, `/parent/child/`, and `/parent/child/grandchild/` to their new URLs.