### PR TITLE
Fix importing of htaccess regex

### DIFF
--- a/includes/fileio/format/class-apache.php
+++ b/includes/fileio/format/class-apache.php
@@ -188,11 +188,13 @@ class Apache extends FileIO {
 		$url = $this->decode_url( $url );
 
 		if ( $this->is_str_regex( $url ) ) {
+			$has_start = strpos( $url, '^' ) === 0;
+			$has_end = substr( $url, -1 ) === '$';
 			$tmp = ltrim( $url, '^' );
 			$tmp = rtrim( $tmp, '$' );
 
 			if ( $this->is_str_regex( $tmp ) ) {
-				return '^/' . ltrim( $tmp, '/' );
+				return ( $has_start ? '^' : '' ) . '/' . ltrim( $tmp, '/' ) . ( $has_end ? '$' : '' );
 			}
 
 			return '/' . ltrim( $tmp, '/' );

--- a/includes/fileio/format/class-apache.php
+++ b/includes/fileio/format/class-apache.php
@@ -140,7 +140,7 @@ class Apache extends FileIO {
 	private function decode_url( $url ) {
 		$url = rawurldecode( $url );
 		$url = (string) preg_replace( '@\\\/@', '/', $url );
-		$url = (string) preg_replace( '@\\\\.@', '\\\\.', $url );
+		$url = (string) preg_replace( '@\\\\\\.@', '\\\\.', $url );
 		return $url;
 	}
 
@@ -170,7 +170,9 @@ class Apache extends FileIO {
 	private function is_regex( $url ) {
 		if ( $this->is_str_regex( $url ) ) {
 			$tmp = ltrim( $url, '^' );
-			$tmp = rtrim( $tmp, '$' );
+			if ( $this->has_end_anchor( $tmp ) ) {
+				$tmp = substr( $tmp, 0, -1 );
+			}
 
 			if ( $this->is_str_regex( $tmp ) ) {
 				return true;
@@ -189,9 +191,11 @@ class Apache extends FileIO {
 
 		if ( $this->is_str_regex( $url ) ) {
 			$has_start = strpos( $url, '^' ) === 0;
-			$has_end = substr( $url, -1 ) === '$';
+			$has_end = $this->has_end_anchor( $url );
 			$tmp = ltrim( $url, '^' );
-			$tmp = rtrim( $tmp, '$' );
+			if ( $has_end ) {
+				$tmp = substr( $tmp, 0, -1 );
+			}
 
 			if ( $this->is_str_regex( $tmp ) ) {
 				return ( $has_start ? '^' : '' ) . '/' . ltrim( $tmp, '/' ) . ( $has_end ? '$' : '' );
@@ -201,6 +205,32 @@ class Apache extends FileIO {
 		}
 
 		return $this->decode_url( $url );
+	}
+
+	/**
+	 * Determine if a regex ends with an unescaped $ anchor.
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	private function has_end_anchor( $url ) {
+		$length = strlen( $url );
+
+		if ( $length === 0 || substr( $url, -1 ) !== '$' ) {
+			return false;
+		}
+
+		$slashes = 0;
+
+		for ( $pos = $length - 2; $pos >= 0; $pos-- ) {
+			if ( substr( $url, $pos, 1 ) !== '\\' ) {
+				break;
+			}
+
+			$slashes++;
+		}
+
+		return $slashes % 2 === 0;
 	}
 
 	/**

--- a/tests/integration/fileio/test-apache.php
+++ b/tests/integration/fileio/test-apache.php
@@ -100,4 +100,14 @@ class ApacheTest extends WP_UnitTestCase {
 		$this->assertEquals( [ 'url' => '/contact/' ], $item['action_data'] );
 		$this->assertEquals( '301', $item['action_code'] );
 	}
+
+	public function testRewriteRulePreservesEscapedDollar() {
+		$apache = new Apache();
+		$item = $apache->get_as_item( 'RewriteRule ^prices\\$$ /prices/ [R=301,L]' );
+
+		$this->assertEquals( '^/prices\\$$', $item['url'] );
+		$this->assertTrue( $item['regex'] );
+		$this->assertEquals( [ 'url' => '/prices/' ], $item['action_data'] );
+		$this->assertEquals( '301', $item['action_code'] );
+	}
 }

--- a/tests/integration/fileio/test-apache.php
+++ b/tests/integration/fileio/test-apache.php
@@ -88,6 +88,16 @@ class ApacheTest extends WP_UnitTestCase {
 		$apache = new Apache();
 		$item = $apache->get_as_item( 'RewriteRule ^products/reporting\.html.*$ /products/ [R,L]' );
 
-		$this->assertEquals( '^/products/reporting\.html.*', $item['url'] );
+		$this->assertEquals( '^/products/reporting\.html.*$', $item['url'] );
+	}
+
+	public function testRewriteRulePreservesOptionalRegexEnd() {
+		$apache = new Apache();
+		$item = $apache->get_as_item( 'RewriteRule ^/contact-us(/.*)?$ /contact/ [R=301,L]' );
+
+		$this->assertEquals( '^/contact-us(/.*)?$', $item['url'] );
+		$this->assertTrue( $item['regex'] );
+		$this->assertEquals( [ 'url' => '/contact/' ], $item['action_data'] );
+		$this->assertEquals( '301', $item['action_code'] );
 	}
 }

--- a/tests/integration/fileio/test-import-csv.php
+++ b/tests/integration/fileio/test-import-csv.php
@@ -41,6 +41,14 @@ class ImportCsvTest extends WP_UnitTestCase {
 		$this->assertTrue( $csv['regex'] );
 	}
 
+	public function testSourceTargetRegexPreservesQuestionMark() {
+		$importer = new Csv();
+		$csv = $importer->csv_as_item( [ '^/contact-us(/.*)?$', '/target' ], Red_Group::get( 1 ) );
+
+		$this->assertTrue( $csv['regex'] );
+		$this->assertEquals( '^/contact-us(/.*)?$', $csv['url'] );
+	}
+
 	public function testRedirectCode() {
 		$importer = new Csv();
 		$csv = $importer->csv_as_item( [ '/source', '/target', 0, 308 ], Red_Group::get( 1 ) );


### PR DESCRIPTION
Importing from htaccess could strip characters if it was a regular expression. Update the handling to detect this.

## Testing

- Unit test included