### PR TITLE
Unify notices

### DIFF
--- a/redirection-admin.php
+++ b/redirection-admin.php
@@ -147,7 +147,7 @@ class Redirection_Admin {
 
 		// Known HTML and so isn't escaped
 		// phpcs:ignore
-		echo '<div class="update-nag notice notice-warning" style="width: 95%">' . $message . '</div>';
+		echo '<div class="update-nag notice notice-warning redirection-notice" style="width: 95%">' . $message . '</div>';
 	}
 
 	/**
@@ -157,7 +157,7 @@ class Redirection_Admin {
 	 */
 	public function show_incomplete_installation_notice() {
 		?>
-		<div class="notice notice-error">
+		<div class="notice notice-error redirection-notice">
 			<p>
 				<strong><?php esc_html_e( 'Redirection Error: Incomplete Installation Detected', 'redirection' ); ?></strong>
 			</p>
@@ -635,7 +635,7 @@ class Redirection_Admin {
 			return;
 		}
 		?>
-		<div class="notice notice-error">
+		<div class="notice notice-error redirection-notice">
 			<h1><?php echo esc_html( $this->fixit_failed->get_error_message() ); ?></h1>
 			<p><?php echo esc_html( $this->fixit_failed->get_error_data() ); ?></p>
 		</div>

--- a/src/component/redirect-edit/warning.tsx
+++ b/src/component/redirect-edit/warning.tsx
@@ -306,7 +306,7 @@ export const Warnings = ( { warnings }: WarningsProps ) => {
 
 	return (
 		<TableRow>
-			<div className="redirect-edit_warning notice notice-warning">
+			<div className="redirect-edit_warning notice notice-warning redirection-notice">
 				{ warnings.map( ( text: React.ReactNode, pos: number ) => (
 					<p key={ pos }>
 						<span className="dashicons dashicons-info" />

--- a/src/page/home/style.scss
+++ b/src/page/home/style.scss
@@ -117,9 +117,17 @@
 	padding-bottom: 10px !important;
 }
 
-/* Some plugins hide .notice - ensure our stuff always shows */
-.notice:not(.hidden) {
+/* Only show Redirection-owned admin notices on Redirection pages. */
+.notice.redirection-notice:not(.hidden),
+.notice.wpl-notice:not(.hidden),
+.update-nag.redirection-notice:not(.hidden),
+.update-nag.wpl-notice:not(.hidden) {
 	display: block !important;
+}
+
+.notice:not(.redirection-notice):not(.wpl-notice):not(.hidden),
+.update-nag:not(.redirection-notice):not(.wpl-notice):not(.hidden) {
+	display: none !important;
 }
 
 .database-switch {


### PR DESCRIPTION
Make sure Redirection notices are always shown on Redirection pages, and other notices are not shown. This should help reduce other plugins hiding Redirection notices on it's own admin pages, while hiding other plugin notices on the same page.