### PR TITLE
Fix warnings with code tags

### DIFF
--- a/src/component/redirect-edit/style.scss
+++ b/src/component/redirect-edit/style.scss
@@ -70,12 +70,15 @@
 			margin-right: 4px;
 		}
 
+		.dashicons-info {
+			position: relative;
+			top: 3px;
+		}
+
 		p {
 			color: #444;
 			margin: 0;
 			line-height: 2;
-			display: flex;
-			align-items: center;
 		}
 
 		code {


### PR DESCRIPTION
Warning notices with child tags would get split up in a bad way because of the flex. The flex was supposed to help align the icon, so use another method for the icon and let the content flow normally