### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/models/log/log.php
+++ b/models/log/log.php
@@ -708,10 +708,10 @@ abstract class Red_Log {
 			return false;
 		}
 
-		fputcsv( $stdout, static::get_csv_header() );
+		fputcsv( $stdout, static::get_csv_header(), ',', '"' , '\\' );
 
 		foreach ( $rows as $row ) {
-			fputcsv( $stdout, array_map( [ $sanitizer, 'escape' ], static::get_csv_row( $row ) ) );
+			fputcsv( $stdout, array_map( [ $sanitizer, 'escape' ], static::get_csv_row( $row ) ), ',', '"' , '\\' );
 		}
 
 		rewind( $stdout );
@@ -786,12 +786,12 @@ abstract class Red_Log {
 			return false;
 		}
 
-		fputcsv( $stdout, array_map( [ static::class, 'get_export_field_label' ], $fields ) );
+		fputcsv( $stdout, array_map( [ static::class, 'get_export_field_label' ], $fields ), ',', '"' , '\\' );
 
 		foreach ( $rows as $row ) {
 			$mapped_row = self::filter_export_row( static::map_export_row( $row ), $fields );
-			fputcsv( $stdout, array_map( [ $sanitizer, 'escape' ], array_values( $mapped_row ) ) );
-		}
+			fputcsv( $stdout, array_map( [ $sanitizer, 'escape' ], array_values( $mapped_row ) ), ',', '"' , '\\' );
+		 }
 
 		rewind( $stdout );
 


### PR DESCRIPTION
# Summary

Fix PHP 8.4 deprecations in `models/log/log.php` by adding explicit `fputcsv()` escape parameter.

## Details

- Updated CSV export calls to use `fputcsv(..., ',', '"', '\\')`
- Prevents deprecated implicit argument behavior in PHP 8.4

## Reason

Resolve PHP 8.4 deprecation warnings caused by `fputcsv()` calls without explicit escape parameter.