### PR TITLE
Add Yoast importer

### DIFF
--- a/includes/import-export/importer/class-plugin-registry.php
+++ b/includes/import-export/importer/class-plugin-registry.php
@@ -22,6 +22,7 @@ class PluginRegistry {
 		'seopress' => Seopress::class,
 		'slim-seo' => SlimSeo::class,
 		'eps-301-redirects' => Eps301Redirects::class,
+		'yoast-seo' => YoastSeo::class,
 		'fake-redirection' => FakeRedirection::class,
 	);
 

--- a/includes/import-export/importer/class-redirect-item-mapper.php
+++ b/includes/import-export/importer/class-redirect-item-mapper.php
@@ -265,7 +265,7 @@ class RedirectItemMapper {
 		$target = isset( $redirect['url'] ) ? (string) $redirect['url'] : '';
 		$code = isset( $redirect['type'] ) ? intval( $redirect['type'], 10 ) : 0;
 		$regex = isset( $redirect['format'] ) && $redirect['format'] === 'regex';
-		$is_error = $code > 400 && $code < 500;
+		$is_error = in_array( $code, array( 400, 401, 403, 404, 410, 418, 451, 500, 501, 502, 503, 504 ), true );
 
 		if ( $origin === '' || $code === 0 || ( $target === '' && ! $is_error ) ) {
 			return false;

--- a/includes/import-export/importer/class-redirect-item-mapper.php
+++ b/includes/import-export/importer/class-redirect-item-mapper.php
@@ -255,4 +255,31 @@ class RedirectItemMapper {
 			'action_code' => $code,
 		);
 	}
+
+	/**
+	 * @param array<string, mixed> $redirect Redirect data.
+	 * @return array<string, mixed>|false
+	 */
+	public function yoast_seo( array $redirect ) {
+		$origin = isset( $redirect['origin'] ) ? (string) $redirect['origin'] : '';
+		$target = isset( $redirect['url'] ) ? (string) $redirect['url'] : '';
+		$code = isset( $redirect['type'] ) ? intval( $redirect['type'], 10 ) : 0;
+		$regex = isset( $redirect['format'] ) && $redirect['format'] === 'regex';
+		$is_error = $code > 400 && $code < 500;
+
+		if ( $origin === '' || $code === 0 || ( $target === '' && ! $is_error ) ) {
+			return false;
+		}
+
+		$source = $regex ? $origin : $this->normalize_source( $origin );
+
+		return array(
+			'url' => $source,
+			'action_data' => array( 'url' => $target === '' ? '' : $this->normalize_target( $target ) ),
+			'regex' => $regex,
+			'match_type' => 'url',
+			'action_type' => $is_error ? 'error' : 'url',
+			'action_code' => $code,
+		);
+	}
 }

--- a/includes/import-export/importer/class-yoast-seo.php
+++ b/includes/import-export/importer/class-yoast-seo.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Redirection\ImportExport\Importer;
+
+/**
+ * @phpstan-import-type ImporterInfo from Plugin
+ */
+class YoastSeo extends Plugin {
+	/**
+	 * @var RedirectItemMapper
+	 */
+	private $mapper;
+
+	public function __construct( ?RedirectItemMapper $mapper = null ) {
+		$this->mapper = $mapper ? $mapper : new RedirectItemMapper();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function supports_preview() {
+		return true;
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>|false>
+	 */
+	protected function get_redirect_items() {
+		$redirects = get_option( 'wpseo-premium-redirects-base' );
+		$items = array();
+
+		if ( is_array( $redirects ) ) {
+			foreach ( $redirects as $redirect ) {
+				if ( is_array( $redirect ) ) {
+					$items[] = $this->mapper->yoast_seo( $redirect );
+				}
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * @return ImporterInfo|false
+	 */
+	public function get_data() {
+		$data = get_option( 'wpseo-premium-redirects-base' );
+
+		if ( is_array( $data ) && count( $data ) > 0 ) {
+			return array(
+				'id' => 'yoast-seo',
+				'name' => 'Yoast SEO Premium',
+				'description' => __( 'Redirects created by Yoast SEO Premium.', 'redirection' ),
+				'source' => __( 'Plugin settings', 'redirection' ),
+				'total' => count( $data ),
+			);
+		}
+
+		return false;
+	}
+}

--- a/redirection-cli.php
+++ b/redirection-cli.php
@@ -112,7 +112,7 @@ class Redirection_Cli extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <name>
-	 * : The plugin name to import from. Supported importers include wp-simple-redirect, seo-redirection, safe-redirect-manager, wordpress-old-slugs, rank-math, quick-redirects, pretty-links, seopress, slim-seo, eps-301-redirects, and fake-redirection.
+	 * : The plugin name to import from. Supported importers include wp-simple-redirect, seo-redirection, safe-redirect-manager, wordpress-old-slugs, rank-math, quick-redirects, pretty-links, seopress, slim-seo, eps-301-redirects, yoast-seo, and fake-redirection.
 	 *
 	 * [--group=<groupid>]
 	 * : The group ID to import into. Defaults to the first available group.

--- a/tests/unit/test-plugin-importers.php
+++ b/tests/unit/test-plugin-importers.php
@@ -15,6 +15,7 @@ use Redirection\ImportExport\Importer\PluginRegistry;
 use Redirection\ImportExport\Importer\QuickRedirects;
 use Redirection\ImportExport\Importer\RankMath;
 use Redirection\ImportExport\Importer\Simple301;
+use Redirection\ImportExport\Importer\YoastSeo;
 use Redirection\ImportExport\Importer\RedirectItemMapper;
 
 /**
@@ -63,6 +64,7 @@ class PluginImporterUnitTest extends TestCase {
 		require_once PLUGIN_PATH . '/includes/import-export/importer/class-simple301.php';
 		require_once PLUGIN_PATH . '/includes/import-export/importer/class-slim-seo.php';
 		require_once PLUGIN_PATH . '/includes/import-export/importer/class-wordpress-old-slugs.php';
+		require_once PLUGIN_PATH . '/includes/import-export/importer/class-yoast-seo.php';
 	}
 
 	private function get_mapper() {
@@ -475,6 +477,197 @@ class PluginImporterUnitTest extends TestCase {
 
 		$this->assertFalse( $mapper->eps301( 'source/', false, 301 ) );
 		$this->assertFalse( $mapper->eps301( 'source/', '/target/', 0 ) );
+	}
+
+	public function testYoastSeoImporterMapsPlainRedirects() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => 'old/url',
+				'url' => 'new/url/301',
+				'type' => 301,
+				'format' => 'plain',
+			]
+		);
+
+		$this->assertSame( '/old/url', $result['url'] );
+		$this->assertSame( '/new/url/301', $result['action_data']['url'] );
+		$this->assertFalse( $result['regex'] );
+		$this->assertSame( 301, $result['action_code'] );
+	}
+
+	public function testYoastSeoImporterKeepsAbsoluteTarget() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => 'this/is/the/old/url-here',
+				'url' => 'https://site.com/new/url',
+				'type' => 307,
+				'format' => 'plain',
+			]
+		);
+
+		$this->assertSame( '/this/is/the/old/url-here', $result['url'] );
+		$this->assertSame( 'https://site.com/new/url', $result['action_data']['url'] );
+		$this->assertFalse( $result['regex'] );
+		$this->assertSame( 307, $result['action_code'] );
+	}
+
+	public function testYoastSeoImporterKeepsRegexSourceUnchanged() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => '/regex/.*',
+				'url' => 'test2/301',
+				'type' => 301,
+				'format' => 'regex',
+			]
+		);
+
+		$this->assertSame( '/regex/.*', $result['url'] );
+		$this->assertSame( '/test2/301', $result['action_data']['url'] );
+		$this->assertTrue( $result['regex'] );
+		$this->assertSame( 301, $result['action_code'] );
+	}
+
+	public function testYoastSeoImporterMapsErrorRedirectsWithEmptyTarget() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => 'gone/page',
+				'url' => '',
+				'type' => 410,
+				'format' => 'plain',
+			]
+		);
+
+		$this->assertSame( '/gone/page', $result['url'] );
+		$this->assertSame( '', $result['action_data']['url'] );
+		$this->assertSame( 'error', $result['action_type'] );
+		$this->assertSame( 410, $result['action_code'] );
+	}
+
+	public function testYoastSeoImporterMapsLegalRedirectsWithEmptyTarget() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => 'blocked/page',
+				'url' => '',
+				'type' => 451,
+				'format' => 'plain',
+			]
+		);
+
+		$this->assertSame( '/blocked/page', $result['url'] );
+		$this->assertSame( '', $result['action_data']['url'] );
+		$this->assertSame( 'error', $result['action_type'] );
+		$this->assertSame( 451, $result['action_code'] );
+	}
+
+	public function testYoastSeoImporterRejectsInvalidRows() {
+		$mapper = $this->get_mapper();
+
+		$this->assertFalse(
+			$mapper->yoast_seo(
+				[
+					'origin' => '',
+					'url' => 'target',
+					'type' => 301,
+					'format' => 'plain',
+				]
+			)
+		);
+		$this->assertFalse(
+			$mapper->yoast_seo(
+				[
+					'origin' => 'source',
+					'url' => '',
+					'type' => 301,
+					'format' => 'plain',
+				]
+			)
+		);
+		$this->assertFalse(
+			$mapper->yoast_seo(
+				[
+					'origin' => 'source',
+					'url' => 'target',
+					'type' => 0,
+					'format' => 'plain',
+				]
+			)
+		);
+	}
+
+	public function testYoastSeoImporterMapsOptionRows() {
+		Functions\when( 'get_option' )->justReturn(
+			[
+				[
+					'origin' => 'old/url',
+					'url' => 'new/url/301',
+					'type' => 301,
+					'format' => 'plain',
+				],
+				[
+					'origin' => '/regex/.*',
+					'url' => 'test2/301',
+					'type' => 301,
+					'format' => 'regex',
+				],
+			]
+		);
+
+		$importer = new class() extends YoastSeo {
+			public function get_items() {
+				return $this->get_redirect_items();
+			}
+		};
+
+		$items = $importer->get_items();
+
+		$this->assertCount( 2, $items );
+		$this->assertSame( '/old/url', $items[0]['url'] );
+		$this->assertSame( '/regex/.*', $items[1]['url'] );
+		$this->assertTrue( $items[1]['regex'] );
+	}
+
+	public function testYoastSeoImporterIgnoresMissingOption() {
+		Functions\when( 'get_option' )->justReturn( false );
+
+		$importer = new class() extends YoastSeo {
+			public function get_items() {
+				return $this->get_redirect_items();
+			}
+		};
+
+		$this->assertSame( [], $importer->get_items() );
+		$this->assertFalse( $importer->get_data() );
+	}
+
+	public function testYoastSeoImporterReportsTotalFromOption() {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'get_option' )->justReturn(
+			[
+				[ 'origin' => 'a', 'url' => 'b', 'type' => 301, 'format' => 'plain' ],
+				[ 'origin' => 'c', 'url' => 'd', 'type' => 302, 'format' => 'plain' ],
+			]
+		);
+
+		$importer = new YoastSeo();
+		$data = $importer->get_data();
+
+		$this->assertSame( 'yoast-seo', $data['id'] );
+		$this->assertSame( 2, $data['total'] );
+		$this->assertTrue( $importer->supports_preview() );
+	}
+
+	public function testPluginImporterRegistryReturnsYoastSeoImporter() {
+		$this->assertInstanceOf( YoastSeo::class, PluginRegistry::get_importer( 'yoast-seo' ) );
 	}
 
 	public function testPreviewPluginResultsReturnsEmptyWhenPreviewNotSupported() {

--- a/tests/unit/test-plugin-importers.php
+++ b/tests/unit/test-plugin-importers.php
@@ -569,6 +569,24 @@ class PluginImporterUnitTest extends TestCase {
 		$this->assertSame( 451, $result['action_code'] );
 	}
 
+	public function testYoastSeoImporterMapsServerErrorRedirectsWithEmptyTarget() {
+		$mapper = $this->get_mapper();
+
+		$result = $mapper->yoast_seo(
+			[
+				'origin' => 'broken/page',
+				'url' => '',
+				'type' => 500,
+				'format' => 'plain',
+			]
+		);
+
+		$this->assertSame( '/broken/page', $result['url'] );
+		$this->assertSame( '', $result['action_data']['url'] );
+		$this->assertSame( 'error', $result['action_type'] );
+		$this->assertSame( 500, $result['action_code'] );
+	}
+
 	public function testYoastSeoImporterRejectsInvalidRows() {
 		$mapper = $this->get_mapper();
 


### PR DESCRIPTION
Add support for Yoast redirects. Data is taken from the `wp_options` value.

<img width="398" height="298" alt="image" src="https://github.com/user-attachments/assets/12c9d6f2-1fc1-482b-9cff-b32e6d8a245e" />
