### PR TITLE
Fix passthrough having no target in UI

### DIFF
--- a/src/lib/redirect-constants.test.js
+++ b/src/lib/redirect-constants.test.js
@@ -1,4 +1,12 @@
-import { getMatchState } from 'lib/redirect-constants';
+import {
+	getMatchState,
+	hasUrlTarget,
+	ACTION_URL,
+	ACTION_RANDOM,
+	ACTION_PASS,
+	ACTION_ERROR,
+	ACTION_NOTHING,
+} from 'lib/redirect-constants';
 
 const URL_FROM = 'https://example.com/matched';
 const URL_NOTFROM = 'https://example.com/unmatched';
@@ -7,6 +15,28 @@ const withUrlFromNotfrom = ( extra ) => ( {
 	url_from: URL_FROM,
 	url_notfrom: URL_NOTFROM,
 	...extra,
+} );
+
+describe( 'hasUrlTarget', () => {
+	test( 'pass-through actions have a URL target', () => {
+		expect( hasUrlTarget( ACTION_PASS ) ).toBe( true );
+	} );
+
+	test( 'redirect to URL actions have a URL target', () => {
+		expect( hasUrlTarget( ACTION_URL ) ).toBe( true );
+	} );
+
+	test( 'random actions do not have a URL target', () => {
+		expect( hasUrlTarget( ACTION_RANDOM ) ).toBe( false );
+	} );
+
+	test( 'error actions do not have a URL target', () => {
+		expect( hasUrlTarget( ACTION_ERROR ) ).toBe( false );
+	} );
+
+	test( 'do-nothing actions do not have a URL target', () => {
+		expect( hasUrlTarget( ACTION_NOTHING ) ).toBe( false );
+	} );
 } );
 
 describe( 'getMatchState', () => {

--- a/src/lib/redirect-constants.ts
+++ b/src/lib/redirect-constants.ts
@@ -28,7 +28,7 @@ export const MATCH_LANGUAGE = 'language';
  * @param actionType
  */
 export function hasUrlTarget( actionType: string ): boolean {
-	return actionType === ACTION_URL || actionType === ACTION_RANDOM;
+	return actionType === ACTION_URL || actionType === ACTION_PASS;
 }
 
 /**


### PR DESCRIPTION
The target for passthrough redirects is missing, and random redirects has a target it doesn't need. This fixes the `hasUrlTarget` list.

Fixes #4266 

## Testing

- Passthrough has target