### PR TITLE
Allow more groups in admin UI

### DIFF
--- a/includes/api/route/class-group.php
+++ b/includes/api/route/class-group.php
@@ -49,6 +49,19 @@ class Group extends Filtered {
 			]
 		);
 
+		// GET /group/dropdown - Lightweight, unpaginated group list for dropdowns
+		register_rest_route(
+			$api_namespace,
+			'/group/dropdown',
+			[
+				[
+					'methods' => WP_REST_Server::READABLE,
+					'callback' => [ $this, 'route_dropdown' ],
+					'permission_callback' => [ $this, 'permission_callback_manage' ],
+				],
+			]
+		);
+
 		// POST /group/:id - Update group
 		register_rest_route(
 			$api_namespace,
@@ -157,6 +170,16 @@ class Group extends Filtered {
 	 */
 	public function route_list( WP_REST_Request $request ) {
 		return \Red_Group::get_filtered( $request->get_params() ); // @phpstan-ignore-line
+	}
+
+	/**
+	 * Get a lightweight, unpaginated group list for use in dropdowns
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request The request.
+	 * @return GroupListResponse
+	 */
+	public function route_dropdown( WP_REST_Request $request ) {
+		return \Red_Group::get_for_dropdown(); // @phpstan-ignore-line
 	}
 
 	/**

--- a/models/group.php
+++ b/models/group.php
@@ -36,6 +36,7 @@ require_once __DIR__ . '/group-filter.php';
 class Red_Group {
 	const DEFAULT_PER_PAGE = 25;
 	const MAX_PER_PAGE = 200;
+	const DROPDOWN_LIMIT = 1000;
 
 	/**
 	 * Group ID
@@ -424,6 +425,62 @@ class Red_Group {
 		return array(
 			'items' => $items,
 			'total' => intval( $total_items, 10 ),
+		);
+	}
+
+	/**
+	 * Get all groups for use in a dropdown/select control
+	 *
+	 * Unlike get_filtered() this doesn't calculate a per-group redirect count, since
+	 * that isn't needed for a dropdown and would mean a query per group.
+	 *
+	 * @return GroupFilteredResult
+	 */
+	public static function get_for_dropdown() {
+		global $wpdb;
+
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, name, module_id, status FROM {$wpdb->prefix}redirection_groups ORDER BY name ASC LIMIT %d",
+				self::DROPDOWN_LIMIT
+			)
+		);
+
+		$options = Red_Options::get();
+		$items = array();
+
+		foreach ( $rows as $row ) {
+			$group = new Red_Group( $row );
+			$group_json = $group->to_dropdown_json();
+
+			if ( $group->get_id() === $options['last_group_id'] ) {
+				$group_json['default'] = true;
+			}
+
+			$items[] = $group_json;
+		}
+
+		return array(
+			'items' => $items,
+			'total' => count( $items ),
+		);
+	}
+
+	/**
+	 * Convert group to a lightweight JSON representation for dropdowns
+	 *
+	 * @return GroupJson
+	 */
+	public function to_dropdown_json() {
+		$module = Red_Module::get( $this->get_module_id() );
+
+		return array(
+			'id' => $this->get_id(),
+			'name' => $this->get_name(),
+			'redirects' => 0,
+			'module_id' => $this->get_module_id(),
+			'moduleName' => $module ? $module->get_name() : '',
+			'enabled' => $this->is_enabled(),
 		);
 	}
 

--- a/src/component/redirect-edit/index.tsx
+++ b/src/component/redirect-edit/index.tsx
@@ -13,7 +13,7 @@ import MatchType from './match-type';
 import MatchTarget from './match';
 import ActionTarget from './action';
 import { getWarningFromState, Warnings } from './warning';
-import { useRedirectUpdate, useRedirectCreate, useGroupList } from 'lib/api/hooks';
+import { useRedirectUpdate, useRedirectCreate, useGroupDropdown } from 'lib/api/hooks';
 import { useTableStore, useSettingsStore, useMessageStore } from 'stores';
 import {
 	ACTION_URL,
@@ -109,7 +109,7 @@ function EditRedirect( props: EditRedirectProps ) {
 	} = props;
 
 	// Get state from stores and queries
-	const { data: groupData, isSuccess: hasLoadedGroups, refetch: refetchGroups } = useGroupList( {} );
+	const { data: groupData, isSuccess: hasLoadedGroups, refetch: refetchGroups } = useGroupDropdown();
 	const groups = useMemo( () => groupData?.items ?? [], [ groupData ] );
 	const addTop = useTableStore( ( state ) => state.redirectsAddTop );
 	const table = useTableStore( ( state ) => state.redirects );

--- a/src/lib/api-request/index.ts
+++ b/src/lib/api-request/index.ts
@@ -22,6 +22,7 @@ export const RedirectionApi = {
 	},
 	group: {
 		list: ( data: TableParams ) => getApiRequest( 'redirection/v1/group', data ),
+		dropdown: () => getApiRequest( 'redirection/v1/group/dropdown' ),
 		update: ( id: number, data: any ) => postApiRequest( 'redirection/v1/group/' + id, data ),
 		create: ( data: any, query?: TableParams ) => postApiRequest( 'redirection/v1/group', data, query ),
 	},

--- a/src/lib/api/hooks/use-group-list.ts
+++ b/src/lib/api/hooks/use-group-list.ts
@@ -8,6 +8,33 @@ import { cleanApiParams } from '../utils';
 import { useMessageStore } from 'stores';
 
 /**
+ * Query hook for fetching the full, unpaginated group list used by dropdowns and filters.
+ *
+ * Unlike useGroupList this doesn't paginate, so it always sees every group (up to the
+ * server-side dropdown limit) rather than only the first page.
+ * @param options
+ */
+export function useGroupDropdown( options?: Omit< UseQueryOptions< GroupListResponse >, 'queryKey' | 'queryFn' > ) {
+	return useQuery( {
+		queryKey: queryKeys.groups.dropdown(),
+		refetchOnMount: 'always',
+		refetchOnReconnect: true,
+		placeholderData: ( previousData ) => previousData,
+		queryFn: async () => {
+			try {
+				const response = await apiFetch( RedirectionApi.group.dropdown() );
+				return GroupListResponseSchema.parse( response );
+			} catch ( error ) {
+				const handledError = handleApiError( error );
+				useMessageStore.getState().addError( handledError.message || 'Failed to fetch groups' );
+				throw handledError;
+			}
+		},
+		...options,
+	} );
+}
+
+/**
  * Query hook for fetching groups list
  * @param params
  * @param options

--- a/src/lib/api/hooks/use-group-mutations.ts
+++ b/src/lib/api/hooks/use-group-mutations.ts
@@ -40,6 +40,7 @@ export function useGroupCreate(
 			decrementProgress();
 			addNotice( 'Group created' );
 			queryClient.invalidateQueries( { queryKey: queryKeys.groups.lists() } );
+			queryClient.invalidateQueries( { queryKey: queryKeys.groups.dropdown() } );
 		},
 		onError: ( error ) => {
 			addError( error.message || 'Failed to create group' );
@@ -74,6 +75,7 @@ export function useGroupUpdate( options?: Omit< UseMutationOptions< Group, Error
 			decrementProgress();
 			addNotice( 'Group saved' );
 			queryClient.invalidateQueries( { queryKey: queryKeys.groups.lists() } );
+			queryClient.invalidateQueries( { queryKey: queryKeys.groups.dropdown() } );
 			queryClient.invalidateQueries( { queryKey: queryKeys.groups.detail( data.id ) } );
 		},
 		onError: ( error ) => {
@@ -111,6 +113,7 @@ export function useGroupDelete(
 			addNotice( 'Groups deleted' );
 			setGroupsSelected( [] );
 			queryClient.invalidateQueries( { queryKey: queryKeys.groups.lists() } );
+			queryClient.invalidateQueries( { queryKey: queryKeys.groups.dropdown() } );
 		},
 		onError: ( error ) => {
 			addError( error.message || 'Failed to delete groups' );
@@ -154,6 +157,7 @@ export function useGroupBulkAction(
 			// Reset to first page and clear selections after any bulk action
 			setGroupsTable( { page: 0, selected: [], selectAll: false } );
 			queryClient.invalidateQueries( { queryKey: queryKeys.groups.lists() } );
+			queryClient.invalidateQueries( { queryKey: queryKeys.groups.dropdown() } );
 		},
 		onError: ( error ) => {
 			addError( error.message || 'Failed to perform group action' );

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -19,6 +19,7 @@ export const queryKeys = {
 		lists: () => [ ...queryKeys.groups.all, 'list' ] as const,
 		list: ( params: any ) => [ ...queryKeys.groups.lists(), params ] as const,
 		detail: ( id: number ) => [ ...queryKeys.groups.all, 'detail', id ] as const,
+		dropdown: () => [ ...queryKeys.groups.all, 'dropdown' ] as const,
 	},
 	logs: {
 		all: [ 'logs' ] as const,

--- a/src/page/export/use-export-page.test.ts
+++ b/src/page/export/use-export-page.test.ts
@@ -1,16 +1,16 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useExport, useExportPreview, useGroupList } from 'lib/api/hooks';
+import { useExport, useExportPreview, useGroupDropdown } from 'lib/api/hooks';
 import useExportPage from './use-export-page';
 
 jest.mock( 'lib/api/hooks', () => ( {
 	...jest.requireActual( 'lib/api/hooks' ),
 	useExport: jest.fn(),
 	useExportPreview: jest.fn(),
-	useGroupList: jest.fn(),
+	useGroupDropdown: jest.fn(),
 } ) );
 const mockUseExport = useExport as jest.MockedFunction< typeof useExport >;
 const mockUseExportPreview = useExportPreview as jest.MockedFunction< typeof useExportPreview >;
-const mockUseGroupList = useGroupList as jest.MockedFunction< typeof useGroupList >;
+const mockUseGroupDropdown = useGroupDropdown as jest.MockedFunction< typeof useGroupDropdown >;
 
 describe( 'useExportPage', () => {
 	let previewTotal = 9;
@@ -25,7 +25,7 @@ describe( 'useExportPage', () => {
 		previewRefetch = jest.fn();
 		exportReset = jest.fn();
 
-		mockUseGroupList.mockReturnValue( {
+		mockUseGroupDropdown.mockReturnValue( {
 			data: {
 				items: [
 					{ id: 11, name: 'Imported redirects', moduleName: 'WordPress' },

--- a/src/page/export/use-export-page.ts
+++ b/src/page/export/use-export-page.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import type { CardMetaItem } from 'component/import-export/card';
-import { useExport, useExportPreview, useGroupList } from 'lib/api/hooks';
+import { useExport, useExportPreview, useGroupDropdown } from 'lib/api/hooks';
 import type { ExportRequestVariables } from 'lib/api/hooks';
 import {
 	getExportFormatLabel,
@@ -75,7 +75,7 @@ interface UseExportPageResult {
 }
 
 function useExportPage(): UseExportPageResult {
-	const { data: groupData } = useGroupList( {} );
+	const { data: groupData } = useGroupDropdown();
 	const groupRows = useMemo( () => ( groupData?.items ?? [] ) as GroupRow[], [ groupData?.items ] );
 	const [ selectedTypes, setSelectedTypes ] = useState< ExportType[] >( [] );
 	const [ redirectScopeType, setRedirectScopeType ] = useState< RedirectScopeType >( 'all' );

--- a/src/page/import/use-import-page.test.ts
+++ b/src/page/import/use-import-page.test.ts
@@ -1,12 +1,12 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useGroupList, useImporterList, useImportRunner } from 'lib/api/hooks';
+import { useGroupDropdown, useImporterList, useImportRunner } from 'lib/api/hooks';
 import { isJsonFile, sniffImportFile } from 'component/import-export/import-sniff';
 import useImportPage from './use-import-page';
 import type { ImportMutationVariables } from 'lib/api/hooks';
 
 jest.mock( 'lib/api/hooks', () => ( {
 	...jest.requireActual( 'lib/api/hooks' ),
-	useGroupList: jest.fn(),
+	useGroupDropdown: jest.fn(),
 	useImporterList: jest.fn(),
 	useImportRunner: jest.fn(),
 } ) );
@@ -17,7 +17,7 @@ jest.mock( 'component/import-export/import-sniff', () => ( {
 	sniffImportFile: jest.fn(),
 } ) );
 
-const mockUseGroupList = useGroupList as jest.MockedFunction< typeof useGroupList >;
+const mockUseGroupDropdown = useGroupDropdown as jest.MockedFunction< typeof useGroupDropdown >;
 const mockUseImporterList = useImporterList as jest.MockedFunction< typeof useImporterList >;
 const mockUseImportRunner = useImportRunner as jest.MockedFunction< typeof useImportRunner >;
 const mockIsJsonFile = isJsonFile as jest.MockedFunction< typeof isJsonFile >;
@@ -71,7 +71,7 @@ describe( 'useImportPage', () => {
 		refetchGroups = jest.fn();
 		confirmSpy = jest.spyOn( window, 'confirm' ).mockImplementation( () => true );
 
-		mockUseGroupList.mockReturnValue( {
+		mockUseGroupDropdown.mockReturnValue( {
 			data: {
 				items: [
 					{ id: 11, name: 'Imported redirects' },
@@ -236,7 +236,7 @@ describe( 'useImportPage', () => {
 	} );
 
 	it( 'refetches groups once when the initial group list is empty', async () => {
-		mockUseGroupList.mockReturnValue( {
+		mockUseGroupDropdown.mockReturnValue( {
 			data: {
 				items: [],
 			},

--- a/src/page/import/use-import-page.ts
+++ b/src/page/import/use-import-page.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { sprintf, __ } from '@wordpress/i18n';
 import { isJsonFile, sniffImportFile, sniffImportText } from 'component/import-export/import-sniff';
-import { useGroupList, useImporterList, useImportRunner } from 'lib/api/hooks';
+import { useGroupDropdown, useImporterList, useImportRunner } from 'lib/api/hooks';
 import type { DuplicateMode, ImportMode, ImportMutationVariables } from 'lib/api/hooks';
 import type { ImportPlugin, ImportState, ImportStats } from './types';
 
@@ -69,7 +69,7 @@ function useImportPage() {
 	const dragDepthRef = useRef< number >( 0 );
 	const hasRetriedEmptyGroups = useRef( false );
 
-	const { data: groupData, isSuccess: hasLoadedGroups, refetch: refetchGroups } = useGroupList( {} );
+	const { data: groupData, isSuccess: hasLoadedGroups, refetch: refetchGroups } = useGroupDropdown();
 	const groupRows = ( groupData?.items ?? [] ) as ImportState[ 'groupRows' ];
 	const hasGroups = groupRows.length > 0;
 	const { data: importerData = [], isLoading: isLoadingImporters } = useImporterList();

--- a/src/page/options/options-form/index.tsx
+++ b/src/page/options/options-form/index.tsx
@@ -8,7 +8,7 @@ import UrlOptions from './url-options';
 import './style.scss';
 import { useSettingsUpdate } from 'lib/api/hooks/use-settings';
 import { useSettingsStore } from 'stores';
-import { useGroupList } from 'lib/api/hooks';
+import { useGroupDropdown } from 'lib/api/hooks';
 import { nestedGroups } from 'lib/wordpress-url';
 
 interface GroupOption {
@@ -40,7 +40,7 @@ function OptionsForm() {
 	const installed = useSettingsStore( ( state ) => state.values?.installed ?? '' );
 	const warning = useSettingsStore( ( state ) => state.values?.warning ?? '' );
 	const settingsPostTypes = useSettingsStore( ( state ) => state.values?.postTypes );
-	const { data: groupData } = useGroupList( {} );
+	const { data: groupData } = useGroupDropdown();
 	const groups = ( groupData?.items ? nestedGroups( groupData.items as any ) : [] ) as GroupOption[];
 	const { mutate: updateSettings } = useSettingsUpdate();
 

--- a/src/page/redirects/index.tsx
+++ b/src/page/redirects/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useRedirectList, useGroupList, useRedirectDelete, useRedirectBulkAction, useExport } from 'lib/api/hooks';
+import { useRedirectList, useGroupDropdown, useRedirectDelete, useRedirectBulkAction, useExport } from 'lib/api/hooks';
 import type { ExportRequestVariables } from 'lib/api/hooks';
 import { useTableStore, useSettingsStore } from 'stores';
 import {
@@ -77,7 +77,7 @@ function Redirects() {
 	} );
 
 	// Fetch groups for dropdown - read directly from Query
-	const { data: groupData, isSuccess: groupSuccess } = useGroupList( {} );
+	const { data: groupData, isSuccess: groupSuccess } = useGroupDropdown();
 	const groupRows = groupData?.items ?? [];
 
 	// Bulk action mutations

--- a/tests/integration/api/test-groups.php
+++ b/tests/integration/api/test-groups.php
@@ -199,14 +199,14 @@ class RedirectionApiGroupTest extends Redirection_Api_Test {
 	}
 
 	// public function testBulkDisable() {
-	// 	$this->createAB();
-	// 	$group = Red_Group::create( 'test', 1 );
+	//  $this->createAB();
+	//  $group = Red_Group::create( 'test', 1 );
 
-	// 	$result = $this->callApi( 'bulk/group/disable', array( 'items' => $group->get_id() ), 'POST' );
-	// 	$this->assertEquals( 3, count( $result->data['items'] ) );
+	//  $result = $this->callApi( 'bulk/group/disable', array( 'items' => $group->get_id() ), 'POST' );
+	//  $this->assertEquals( 3, count( $result->data['items'] ) );
 
-	// 	$group = Red_Group::get( $group->get_id() );
-	// 	$this->assertFalse( $group->is_enabled() );
+	//  $group = Red_Group::get( $group->get_id() );
+	//  $this->assertFalse( $group->is_enabled() );
 	// }
 
 	public function testBulkEnable() {
@@ -265,5 +265,18 @@ class RedirectionApiGroupTest extends Redirection_Api_Test {
 
 		$result = $this->callApi( 'group', array( 'moduleId' => 2, 'name' => 'yes', 'id' => 0 ), 'POST' );
 		$this->assertEquals( 3, count( $result->data['items'] ) );
+	}
+
+	public function testDropdownNoPermission() {
+		$this->setUnauthorised();
+
+		$this->check_endpoints( [ [ 'group/dropdown', 'GET', [] ] ] );
+	}
+
+	public function testDropdownReturnsAllGroups() {
+		$this->createAB( 30 );
+
+		$result = $this->callApi( 'group/dropdown' );
+		$this->assertEquals( 30, count( $result->data['items'] ) );
 	}
 }

--- a/tests/integration/models/test-group.php
+++ b/tests/integration/models/test-group.php
@@ -12,4 +12,56 @@ class GroupTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $group !== false );
 	}
+
+	public function testDropdownIgnoresRedirectCount() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_groups" );
+		$group = Red_Group::create( 'group with redirects', 1 );
+
+		Red_Item::create(
+			[
+				'url' => 'url',
+				'match_type' => 'url',
+				'action_type' => 'url',
+				'group_id' => $group->get_id(),
+			]
+		);
+
+		$result = Red_Group::get_for_dropdown();
+
+		$this->assertEquals( 0, $result['items'][0]['redirects'] );
+	}
+
+	public function testDropdownDoesNotQueryPerGroup() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_groups" );
+		for ( $i = 0; $i < 10; $i++ ) {
+			Red_Group::create( 'group' . $i, 1 );
+		}
+
+		$before = $wpdb->num_queries;
+		Red_Group::get_for_dropdown();
+		$queries = $wpdb->num_queries - $before;
+
+		$this->assertLessThan( 5, $queries );
+	}
+
+	public function testDropdownLimit() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}redirection_groups" );
+
+		$values = [];
+		for ( $i = 0; $i < Red_Group::DROPDOWN_LIMIT + 5; $i++ ) {
+			$values[] = $wpdb->prepare( '(%s, %d, %d, %s)', 'group' . $i, 1, $i, 'enabled' );
+		}
+
+		$wpdb->query( "INSERT INTO {$wpdb->prefix}redirection_groups (name, module_id, position, status) VALUES " . implode( ',', $values ) );
+
+		$result = Red_Group::get_for_dropdown();
+
+		$this->assertCount( Red_Group::DROPDOWN_LIMIT, $result['items'] );
+	}
 }


### PR DESCRIPTION
The group dropdown in the admin UI is limited by the per-page of whatever page is visible. This means if you have more groups than that limit they won't be available.

Although not fixing the underlying problem, this does create a seperate endpoint for dropdowns, and increases the limit to one way above what should realistically be used.

It also optimises the query so we don't get redirect counts when they aren't needed.

## Testing

- Add more than 25 groups
- Confirm they are still available