### PR TITLE
Make refactor mode the default runtime path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,6 @@
 		"lint": "@php ./vendor/bin/phpcs --standard=phpcs.xml -s -n",
 		"format": "@php ./vendor/bin/phpcbf --standard=phpcs.xml -n",
 		"format-file": "@php ./vendor/bin/phpcbf --standard=phpcs.xml -n --",
-		"test:integration:refactor": "REDIRECTION_REFACTOR=1 php -d display_errors=1 -d display_startup_errors=1 ./vendor/bin/phpunit --testsuite integration --colors=always --configuration phpunit-integration.xml --exclude-group AdminOnly,,",
-		"test:unit:refactor": "REDIRECTION_REFACTOR=1 ./vendor/bin/phpunit --colors=always --configuration phpunit-unit.xml",
 		"test-integration": "./vendor/bin/phpunit --testsuite integration --colors=always --configuration phpunit-integration.xml --exclude-group AdminOnly,,",
 		"test-unit": "./vendor/bin/phpunit --colors=always --configuration phpunit-unit.xml"
 	},

--- a/redirection.php
+++ b/redirection.php
@@ -97,14 +97,15 @@ function redirection_autoload( $requested_class ) {
 spl_autoload_register( 'redirection_autoload' );
 
 /**
- * Set REDIRECTION_REFACTOR to true to enable the refactor mode, using autoloading for all classes.
- * This is implemented as a dual-mode plugin to allow for a smooth(er) transition to the new codebase.
+ * Refactor mode - using autoloading for all classes under includes/ - is now the only supported
+ * runtime mode. The REDIRECTION_REFACTOR constant is no longer read. The pre-refactor files
+ * (models/, redirection-admin.php, redirection-front.php, redirection-cli.php,
+ * redirection-settings.php) are left in place for reference but are no longer reachable.
  *
  * @return bool
  */
 function red_is_refactor_enabled() {
-	// @phpstan-ignore booleanAnd.rightAlwaysTrue
-	return defined( 'REDIRECTION_REFACTOR' ) && REDIRECTION_REFACTOR;
+	return true;
 }
 
 if ( red_is_refactor_enabled() ) {

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -10,9 +10,9 @@ use Redirection\Database\Schema\Latest;
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 define( 'PLUGIN_PATH', dirname( __DIR__ ) );
-$redirection_refactor = filter_var( getenv( 'REDIRECTION_REFACTOR' ), FILTER_VALIDATE_BOOLEAN );
 
-if ( $redirection_refactor && ! defined( 'REDIRECTION_REFACTOR' ) ) {
+// Refactor mode is now the only supported mode, so it's always on for tests.
+if ( ! defined( 'REDIRECTION_REFACTOR' ) ) {
 	define( 'REDIRECTION_REFACTOR', true );
 }
 

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -4,14 +4,11 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 define( 'PLUGIN_PATH', dirname( __DIR__ ) );
 
-$redirection_refactor = filter_var( getenv( 'REDIRECTION_REFACTOR' ), FILTER_VALIDATE_BOOLEAN );
-
-if ( $redirection_refactor && ! defined( 'REDIRECTION_REFACTOR' ) ) {
+// Refactor mode is now the only supported mode, so it's always on for tests.
+if ( ! defined( 'REDIRECTION_REFACTOR' ) ) {
 	define( 'REDIRECTION_REFACTOR', true );
 }
 
-if ( defined( 'REDIRECTION_REFACTOR' ) && REDIRECTION_REFACTOR ) {
-	require_once PLUGIN_PATH . '/redirection-refactor.php';
-}
+require_once PLUGIN_PATH . '/redirection-refactor.php';
 
 require PLUGIN_PATH . '/tests/unit-test.php';


### PR DESCRIPTION
## Summary
- `red_is_refactor_enabled()` now always returns `true`, so the autoloaded `includes/` codebase is the sole runtime path instead of being gated behind the `REDIRECTION_REFACTOR` constant.
- The pre-refactor files (`models/`, `redirection-admin.php`, `redirection-front.php`, `redirection-cli.php`, `redirection-settings.php`) are left in place for reference but are no longer reachable.
- `tests/bootstrap-unit.php` / `tests/bootstrap-integration.php` now always define `REDIRECTION_REFACTOR`, so the default `composer test-unit` / `test-integration` scripts (what CI runs) exercise the refactor path, including previously env-gated refactor-only test behaviour.
- Removed the now-redundant `test:unit:refactor` / `test:integration:refactor` composer scripts.

This is a one-way switch: there is no supported way to opt back into the legacy code path.

## Test plan
- [x] `composer run analyse` (phpstan.neon and phpstan-max.neon) — clean, no dead-code warnings on the now-unreachable branches
- [x] `composer run lint` (phpcs) — clean (one pre-existing, unrelated docblock-order warning confirmed present before this change)
- [x] `composer test-unit` — 258 tests, 517 assertions, passing
- [x] `composer test-integration` (via wp-env) — 655 tests, 1753 assertions, passing
